### PR TITLE
Add podAnnotations section to helm chart

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "chart.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}        
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -50,3 +50,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+podAnnotations: {}


### PR DESCRIPTION
Fixes issue https://github.com/obsidiandynamics/kafdrop/issues/2

Allow adding annotation to the Pod