### PR TITLE
feat(core): file location as parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,17 @@ docker run -d --rm -p 9000:9000 \
     -e KAFKA_KEYSTORE=$(cat kafka.keystore.jks | base64) \       # optional
     obsidiandynamics/kafdrop
 ```
+#### Environment Variables
+
+|Name |Comment|
+|----------------------|-------------------------------|
+|KAFKA_PROPERTIES_FILE |Localtion where kafka.properties file will be written (if KAFKA_PROPERTIES is set), and read by the application|
+|KAFKA_TRUSTSTORE_FILE|Location where the kafka.truststore.jks file will be written (if KAFKA_TRUSTSTORE is set) and read by the application |
+|KAFKA_KEYSTORE_FILE|Location where the kafka.keystore.jks file will be written(if KAFKA_KEYSTORE is set) and read by the application  |
+|KAFKA_BROKERCONNECT|The broker you wan to connect to. Optionnal if set in 'kafka.properties' or if you connect to 'localhost'|
+|KAFKA_PROPERTIES|base64 encoded string of your properties file. Include the trustore/keystore password, locations, connection encryption, broker address etc. |
+|KAFKA_TRUSTSTORE|base64 encoded string of your truststore file.|
+|KAFKA_KEYSTORE|base64 encoded string of your keystore file.|
 
 ### Using Helm
 Like in the Docker example, supply the files in base-64 form:

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ docker run -d --rm -p 9000:9000 \
 |KAFKA_PROPERTIES|base64 encoded string of your properties file. Include the trustore/keystore password, locations, connection encryption, broker address etc. |
 |KAFKA_TRUSTSTORE|base64 encoded string of your truststore file.|
 |KAFKA_KEYSTORE|base64 encoded string of your keystore file.|
+|HEAP_ARGS|Override default Xms, Xmx|
 
 ### Using Helm
 Like in the Docker example, supply the files in base-64 form:

--- a/README.md
+++ b/README.md
@@ -188,7 +188,6 @@ docker run -d --rm -p 9000:9000 \
 |KAFKA_PROPERTIES|base64 encoded string of your properties file. Include the trustore/keystore password, locations, connection encryption, broker address etc. |
 |KAFKA_TRUSTSTORE|base64 encoded string of your truststore file.|
 |KAFKA_KEYSTORE|base64 encoded string of your keystore file.|
-|HEAP_ARGS|Override default Xms, Xmx|
 
 ### Using Helm
 Like in the Docker example, supply the files in base-64 form:

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ docker run -d --rm -p 9000:9000 \
 
 |Name |Comment|
 |----------------------|-------------------------------|
-|KAFKA_PROPERTIES_FILE |Localtion where kafka.properties file will be written (if KAFKA_PROPERTIES is set), and read by the application|
+|KAFKA_PROPERTIES_FILE |Location where kafka.properties file will be written (if KAFKA_PROPERTIES is set), and read by the application|
 |KAFKA_TRUSTSTORE_FILE|Location where the kafka.truststore.jks file will be written (if KAFKA_TRUSTSTORE is set) and read by the application |
 |KAFKA_KEYSTORE_FILE|Location where the kafka.keystore.jks file will be written(if KAFKA_KEYSTORE is set) and read by the application  |
 |KAFKA_BROKERCONNECT|The broker you wan to connect to. Optionnal if set in 'kafka.properties' or if you connect to 'localhost'|

--- a/src/main/docker/kafdrop.sh
+++ b/src/main/docker/kafdrop.sh
@@ -35,7 +35,7 @@ if [ $JMX_PORT ]; then
     -Djava.rmi.server.hostname=$HOST"
 fi
 
-KAFKA_PROPERTIES_FILE=kafka.properties
+KAFKA_PROPERTIES_FILE=${KAFKA_PROPERTIES_FILE:-/kafka.properties}
 if [ "$KAFKA_PROPERTIES" != "" ]; then
   echo Writing Kafka properties into $KAFKA_PROPERTIES_FILE
   echo $KAFKA_PROPERTIES | base64 --decode > $KAFKA_PROPERTIES_FILE
@@ -43,7 +43,7 @@ else
   rm $KAFKA_PROPERTIES_FILE |& > /dev/null | true
 fi
 
-KAFKA_TRUSTSTORE_FILE=kafka.truststore.jks
+KAFKA_TRUSTSTORE_FILE=${KAFKA_TRUSTSTORE_FILE:-/kafka.truststore.jks}
 if [ "$KAFKA_TRUSTSTORE" != "" ]; then
   echo Writing Kafka truststore into $KAFKA_TRUSTSTORE_FILE
   echo $KAFKA_TRUSTSTORE | base64 --decode > $KAFKA_TRUSTSTORE_FILE
@@ -51,7 +51,7 @@ else
   rm $KAFKA_TRUSTSTORE_FILE |& > /dev/null | true
 fi
 
-KAFKA_KEYSTORE_FILE=kafka.keystore.jks
+KAFKA_KEYSTORE_FILE=${KAFKA_KEYSTORE_FILE:-/kafka.keystore.jks}
 if [ "$KAFKA_KEYSTORE" != "" ]; then
   echo Writing Kafka keystore into $KAFKA_KEYSTORE_FILE
   echo $KAFKA_KEYSTORE | base64 --decode > $KAFKA_KEYSTORE_FILE

--- a/src/main/docker/kafdrop.sh
+++ b/src/main/docker/kafdrop.sh
@@ -22,7 +22,7 @@ fi
 
 # Marathon passes memory limit
 if [ $MARATHON_APP_RESOURCE_MEM ]; then
-    HEAP_ARGS="$HEAP_ARGS -Xms${MARATHON_APP_RESOURCE_MEM%.*}m -Xmx${MARATHON_APP_RESOURCE_MEM%.*}m"
+    HEAP_ARGS="-Xms${MARATHON_APP_RESOURCE_MEM%.*}m -Xmx${MARATHON_APP_RESOURCE_MEM%.*}m"
 fi
 
 if [ $JMX_PORT ]; then

--- a/src/main/docker/kafdrop.sh
+++ b/src/main/docker/kafdrop.sh
@@ -22,7 +22,7 @@ fi
 
 # Marathon passes memory limit
 if [ $MARATHON_APP_RESOURCE_MEM ]; then
-    HEAP_ARGS="-Xms${MARATHON_APP_RESOURCE_MEM%.*}m -Xmx${MARATHON_APP_RESOURCE_MEM%.*}m"
+    HEAP_ARGS="$HEAP_ARGS -Xms${MARATHON_APP_RESOURCE_MEM%.*}m -Xmx${MARATHON_APP_RESOURCE_MEM%.*}m"
 fi
 
 if [ $JMX_PORT ]; then

--- a/src/main/java/kafdrop/config/KafkaConfiguration.java
+++ b/src/main/java/kafdrop/config/KafkaConfiguration.java
@@ -1,5 +1,7 @@
 package kafdrop.config;
 
+import java.io.*;
+import java.util.*;
 import lombok.*;
 import org.apache.kafka.clients.*;
 import org.apache.kafka.common.config.*;
@@ -7,8 +9,6 @@ import org.slf4j.*;
 import org.springframework.boot.context.properties.*;
 import org.springframework.stereotype.*;
 
-import java.io.*;
-import java.util.*;
 
 @Component
 @ConfigurationProperties(prefix = "kafka")
@@ -16,14 +16,15 @@ import java.util.*;
 public final class KafkaConfiguration {
   private static final Logger LOG = LoggerFactory.getLogger(KafkaConfiguration.class);
 
-  private static final String KAFKA_PROPERTIES_FILE = "kafka.properties";
-  private static final String KAFKA_TRUSTSTORE_FILE = "kafka.truststore.jks";
-  private static final String KAFKA_KEYSTORE_FILE = "kafka.keystore.jks";
-
   private String brokerConnect;
   private Boolean isSecured = false;
   private String saslMechanism;
   private String securityProtocol;
+  private String truststoreLocation;
+  private String propertiesFileLocation;
+  private String keystoreLocation;
+
+
 
   public void applyCommon(Properties properties) {
     properties.setProperty(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, brokerConnect);
@@ -33,19 +34,19 @@ public final class KafkaConfiguration {
       properties.put(SaslConfigs.SASL_MECHANISM, saslMechanism);
     }
 
-    if (new File(KAFKA_TRUSTSTORE_FILE).isFile()) {
-      LOG.info("Assigning truststore location to {}", KAFKA_TRUSTSTORE_FILE);
-      properties.put("ssl.truststore.location", KAFKA_TRUSTSTORE_FILE);
+    if (new File(truststoreLocation).isFile()) {
+      LOG.info("Assigning truststore location to {}", truststoreLocation);
+      properties.put("ssl.truststore.location", truststoreLocation);
     }
 
-    if (new File(KAFKA_KEYSTORE_FILE).isFile()) {
-      LOG.info("Assigning keystore location to {}", KAFKA_KEYSTORE_FILE);
-      properties.put("ssl.keystore.location", KAFKA_KEYSTORE_FILE);
+    if (new File(keystoreLocation).isFile()) {
+      LOG.info("Assigning keystore location to {}", keystoreLocation);
+      properties.put("ssl.keystore.location", keystoreLocation);
     }
 
-    final var propertiesFile = new File(KAFKA_PROPERTIES_FILE);
+    final var propertiesFile = new File(propertiesFileLocation);
     if (propertiesFile.isFile()) {
-      LOG.info("Loading properties from {}", KAFKA_PROPERTIES_FILE);
+      LOG.info("Loading properties from {}", propertiesFileLocation);
       final var propertyOverrides = new Properties();
       try (var propsReader = new BufferedReader(new FileReader(propertiesFile))) {
         propertyOverrides.load(propsReader);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,3 +31,6 @@ kafka:
   isSecured: false
   saslMechanism: "PLAIN"
   securityProtocol: "SASL_PLAINTEXT"
+  truststoreLocation : "${TRUSTSTORE_LOCATION:/kafka.truststore.jks}"
+  propertiesFileLocation : "${KAFKA_PROPERTIES_FILE:/kafka.properties}"
+  keystoreLocation : "${KEYSTORE_LOCATION:/kafka.keystore.jks}"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,6 @@ kafka:
   isSecured: false
   saslMechanism: "PLAIN"
   securityProtocol: "SASL_PLAINTEXT"
-  truststoreLocation : "${TRUSTSTORE_LOCATION:/kafka.truststore.jks}"
+  truststoreLocation : "${KAFKA_TRUSTSTORE_FILE:/kafka.truststore.jks}"
   propertiesFileLocation : "${KAFKA_PROPERTIES_FILE:/kafka.properties}"
-  keystoreLocation : "${KEYSTORE_LOCATION:/kafka.keystore.jks}"
+  keystoreLocation : "${KAFKA_KEYSTORE_FILE:/kafka.keystore.jks}"


### PR DESCRIPTION
Fix #38

Allow kafka configuration, truststore and keystore files to be set via env.
