### PR TITLE
Catch and handle UnsupportedVersionException in describeTopicConfigs

### DIFF
--- a/src/main/java/kafdrop/service/KafkaHighLevelAdminClient.java
+++ b/src/main/java/kafdrop/service/KafkaHighLevelAdminClient.java
@@ -106,7 +106,7 @@ public final class KafkaHighLevelAdminClient {
       }
     } catch (InterruptedException | ExecutionException e) {
       if (e.getCause() instanceof UnsupportedVersionException) {
-        return new HashMap<>();
+        return Map.of();
       }
       if (e.getCause() instanceof TopicAuthorizationException) {
         printAcls();

--- a/src/main/java/kafdrop/service/KafkaHighLevelAdminClient.java
+++ b/src/main/java/kafdrop/service/KafkaHighLevelAdminClient.java
@@ -105,6 +105,9 @@ public final class KafkaHighLevelAdminClient {
         configsByTopic.put(entry.getKey().name(), entry.getValue());
       }
     } catch (InterruptedException | ExecutionException e) {
+      if (e.getCause() instanceof UnsupportedVersionException) {
+        return new HashMap<>();
+      }
       if (e.getCause() instanceof TopicAuthorizationException) {
         printAcls();
       }


### PR DESCRIPTION
Fixes #53 using [this solution](https://github.com/obsidiandynamics/kafdrop/issues/53#issuecomment-562234908) recommended by @ekoutanov.

We experience the "broker does not support DESCRIBE_CONFIGS" error using Azure Event Hubs for Kafka. Because it's a managed service we don't have the ability to upgrade the broker.

FWIW Azure is aware of the issue, but haven't given a timeline for a fix https://github.com/Azure/azure-event-hubs-for-kafka/issues/61