### PR TITLE
Make nodeport optional

### DIFF
--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -14,7 +14,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-      nodePort: {{ .Values.service.nodePort }}
+{{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      nodePort: {{.Values.service.nodePort}}
+{{ end }}
   selector:
     app.kubernetes.io/name: {{ include "chart.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
In some use cases, users of kafdrop may opt for clusterIP or other K8s
Service Types.
This help avoid errors from helm when installing the service.
Such error may be expressed as:
```
Forbidden: ... may not be used when `type` is 'ClusterIP'
```
Ref:
1. https://github.com/kubernetes/kubectl/issues/221
2. Similar issue: https://github.com/helm/charts/issues/16940

Signed-off-by: Luong Vo <vo.tran.thanh.luong@gmail.com>