### PR TITLE
Provide type registries for protobuf json format

### DIFF
--- a/src/main/java/kafdrop/util/ProtobufMessageDeserializer.java
+++ b/src/main/java/kafdrop/util/ProtobufMessageDeserializer.java
@@ -84,7 +84,11 @@ public class ProtobufMessageDeserializer implements MessageDeserializer {
       Descriptor messageType = msgTypes.get(0);
 
       DynamicMessage dMsg = DynamicMessage.parseFrom(messageType, CodedInputStream.newInstance(buffer));
-      Printer printer = JsonFormat.printer();
+
+      JsonFormat.TypeRegistry typeRegistry = JsonFormat.TypeRegistry.newBuilder()
+        .add(descs.stream().flatMap(desc -> desc.getMessageTypes().stream()).collect(Collectors.toList()))
+        .build();
+      Printer printer = JsonFormat.printer().usingTypeRegistry(typeRegistry);
 
       return printer.print(dMsg).replaceAll("\n", ""); // must remove line break so it defaults to collapse mode
     } catch (FileNotFoundException e) {


### PR DESCRIPTION
Hi,

In order to let protobuf `JsonFormat` print `google.protobuf.Any` message we need to provide type registries for all types which may appear in `Any`.
For that I propose to configure `JsonFormat` with type registries from the description provided by the user.

See the reference https://developers.google.com/protocol-buffers/docs/reference/java/com/google/protobuf/util/JsonFormat.Printer.html#usingTypeRegistry-com.google.protobuf.util.JsonFormat.TypeRegistry-