### PR TITLE
Update KafkaMonitorImpl.java

### DIFF
--- a/src/main/java/kafdrop/service/KafkaMonitorImpl.java
+++ b/src/main/java/kafdrop/service/KafkaMonitorImpl.java
@@ -117,23 +117,29 @@ public final class KafkaMonitorImpl implements KafkaMonitor {
 
   private Map<String, TopicVO> getTopicMetadata(String... topics) {
     final var topicInfos = highLevelConsumer.getTopicInfos(topics);
+    
     final var retrievedTopicNames = topicInfos.keySet();
-    final var topicConfigs = highLevelAdminClient.describeTopicConfigs(retrievedTopicNames);
-
-    for (var topicVo : topicInfos.values()) {
-      final var config = topicConfigs.get(topicVo.getName());
-      if (config != null) {
-        final var configMap = new TreeMap<String, String>();
-        for (var configEntry : config.entries()) {
-          if (configEntry.source() != ConfigSource.DEFAULT_CONFIG &&
-              configEntry.source() != ConfigSource.STATIC_BROKER_CONFIG) {
-            configMap.put(configEntry.name(), configEntry.value());
-          }
-        }
-        topicVo.setConfig(configMap);
-      } else {
-        LOG.warn("Missing config for topic {}", topicVo.getName());
-      }
+       try
+    {
+    	   final var topicConfigs = highLevelAdminClient.describeTopicConfigs(retrievedTopicNames);
+    	   for (var topicVo : topicInfos.values()) {
+    	      final var config = topicConfigs.get(topicVo.getName());
+    	      if (config != null) {
+    	        final var configMap = new TreeMap<String, String>();
+    	        for (var configEntry : config.entries()) {
+    	          if (configEntry.source() != ConfigSource.DEFAULT_CONFIG &&
+    	              configEntry.source() != ConfigSource.STATIC_BROKER_CONFIG) {
+    	            configMap.put(configEntry.name(), configEntry.value());
+    	          }
+    	        }
+    	        topicVo.setConfig(configMap);
+    	      } else {
+    	        LOG.warn("Missing config for topic {}", topicVo.getName());
+    	      }
+    	    }
+    }
+    catch (KafkaAdminClientException exc) {
+    	LOG.warn("Ignoring KafkaAdminClientException in highLevelAdminClient.describeTopicConfigs. This require write ACL enabled on topics");
     }
     return topicInfos;
   }


### PR DESCRIPTION
If a consumer only have readonly access to Topics or groups highLevelAdminClient.describeTopicConfigs(retrievedTopicNames); throws KafkaAdminClientException which stop Kafkadrop to run. Handling and ignoring exception let kafdrop works in read only mode