### PR TITLE
Total size for topic can be a misnomer.

### DIFF
--- a/src/main/resources/templates/topic-detail.ftl
+++ b/src/main/resources/templates/topic-detail.ftl
@@ -55,7 +55,7 @@
                     <td <#if topic.underReplicatedPartitions?size gt 0>class="warning"</#if>>${topic.underReplicatedPartitions?size}</td>
                 </tr>
                 <tr>
-                    <td>Total size</td>
+                    <td>Total number of msgs published, ever</td>
                     <td>${topic.totalSize}</td>
                 </tr>
                 <tr>


### PR DESCRIPTION
It suggests size in bytes.
its actually 'total number of messages published to the topic, ever'
Better to avoid confusion.

