### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ For all Helm configuration options, have a peek into [chart/values.yaml](chart/v
 
 Replace `3.x.x` with the image tag of [obsidiandynamics/kafdrop](https://hub.docker.com/r/obsidiandynamics/kafdrop). Services will be bound on port 9000 by default (node port 30900).
 
-**Note:** The context path _must_ end with a slash.
+**Note:** The context path _must_ begin with a slash.
 
 Proxy to the Kubernetes cluster:
 ```sh


### PR DESCRIPTION
I tried to use `server.servlet.contextPath: kafka/` per this advice, but got the following error message:

    Caused by: java.lang.IllegalArgumentException: ContextPath must start with '/' and not end with '/'

`/kafka` worked as expected, so I guess this advice just needs to be inverted.