### PR TITLE
Update getTopicInfos to only fetch existing topics

### DIFF
--- a/src/main/java/kafdrop/service/KafkaHighLevelConsumer.java
+++ b/src/main/java/kafdrop/service/KafkaHighLevelConsumer.java
@@ -201,14 +201,16 @@ public final class KafkaHighLevelConsumer {
 
   synchronized Map<String, TopicVO> getTopicInfos(String[] topics) {
     initializeClient();
+    final var topicSet = kafkaConsumer.listTopics().keySet();
     if (topics.length == 0) {
-      final var topicSet = kafkaConsumer.listTopics().keySet();
       topics = Arrays.copyOf(topicSet.toArray(), topicSet.size(), String[].class);
     }
     final var topicVos = new HashMap<String, TopicVO>(topics.length, 1f);
 
     for (var topic : topics) {
-      topicVos.put(topic, getTopicInfo(topic));
+      if (topicSet.contains(topic)) {
+        topicVos.put(topic, getTopicInfo(topic));
+      }
     }
 
     return topicVos;


### PR DESCRIPTION
I updated getTopicInfos in KafkaHighLevelConsumer to not fetch metadata for non-existing topics. This could prevent unintentional creation of topics.