### PR TITLE
Add github actions to publish helm chart

### DIFF
--- a/.github/workflows/publish_helm_chart.yml
+++ b/.github/workflows/publish_helm_chart.yml
@@ -1,0 +1,39 @@
+name: Package and Release Kafdrop helm chart
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: Azure/setup-helm@v1
+    - uses: actions/checkout@master
+
+    - name: Prepare gh-pages branch
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git fetch -a
+        git checkout gh-pages
+        git rebase master -s ours -f
+
+    - name: Package
+      run: cd chart && helm package .
+
+    - name: Build
+      run: cd chart && helm repo index .
+
+    - name: Commit files
+      run: |
+        git add chart/index.yaml
+        git add chart/kafdrop-*.tgz
+        git commit -m "Release new Helm chart version" -a
+
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        branch: gh-pages
+        force: true
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I have setup a github actions to publish Kafdrop helm chart. It uses local github pages in order to publish Charts. 

In order to set this up, you will have to push a new branch `gh-pages` to the main repository and configure [Github pages in your repository settings.](https://help.github.com/en/github/working-with-github-pages/creating-a-github-pages-site)

After merging to master, a new Chart will be updated every time master branch is updated.
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/660283/80314220-d90d1400-8822-11ea-9979-78efea8245b1.png">

After the Actions step is complete, the chart is available in your github pages configured URL - 
<img width="559" alt="image" src="https://user-images.githubusercontent.com/660283/80314357-b4fe0280-8823-11ea-85cc-62227eface26.png">

<img width="559" alt="image" src="https://user-images.githubusercontent.com/660283/80314369-cba45980-8823-11ea-955c-f771e476a4e3.png">



Known issue:
- Because the branch gh-pages has to be kept updated with master in order to publish changes, the rebase step uses `ours` as the strategy to give priority to master changes in case of a conflict. Due to this, only 1 chart version can remain in the chart directory. 

Closes #98 

