### PR TITLE
Bumping api version for Deployment

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "chart.fullname" . }}


### PR DESCRIPTION
Bumping api version for kubernetes Deployment template as apps/v1beta2 is no longer supported by
kubernetes >= v1.16 (which is now the default version on docker for windows).