### PR TITLE
Configure topic deletion with --topic.deleteEnabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,13 @@ You can also disable CORS entirely with the following configuration:
 cors.enabled=false
 ```
 
+## Topic Configuration
+By default, you could delete a topic. If you don't want this feature, you could disable it with:
+
+```
+--topic.deleteEnabled=false
+```
+
 ## Actuator
 Health and info endpoints are available at the following path: `/actuator`
 

--- a/src/main/java/kafdrop/controller/TopicController.java
+++ b/src/main/java/kafdrop/controller/TopicController.java
@@ -21,6 +21,9 @@ package kafdrop.controller;
 import io.swagger.annotations.*;
 import kafdrop.model.*;
 import kafdrop.service.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.*;
 import org.springframework.ui.*;
@@ -28,13 +31,20 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.*;
 
+/**
+ * Handles requests for the topic page.
+ */
 @Controller
 @RequestMapping("/topic")
 public final class TopicController {
+  private static final Logger LOG = LoggerFactory.getLogger(TopicController.class);
   private final KafkaMonitor kafkaMonitor;
+  private final boolean topicDeleteEnabled;
 
-  public TopicController(KafkaMonitor kafkaMonitor) {
+  public TopicController(KafkaMonitor kafkaMonitor,
+                         @Value("${topic.deleteEnabled:true}") Boolean topicDeleteEnabled) {
     this.kafkaMonitor = kafkaMonitor;
+    this.topicDeleteEnabled = topicDeleteEnabled;
   }
 
   @RequestMapping("/{name:.+}")
@@ -43,12 +53,18 @@ public final class TopicController {
         .orElseThrow(() -> new TopicNotFoundException(topicName));
     model.addAttribute("topic", topic);
     model.addAttribute("consumers", kafkaMonitor.getConsumers(Collections.singleton(topic)));
+    model.addAttribute("topicDeleteEnabled", topicDeleteEnabled);
 
     return "topic-detail";
   }
 
   @RequestMapping(value = "/{name:.+}/delete", method = RequestMethod.POST)
   public String deleteTopic(@PathVariable("name") String topicName, Model model) {
+    if (!topicDeleteEnabled) {
+      model.addAttribute("deleteErrorMessage", "Not configured to be deleted.");
+      return topicDetails(topicName, model);
+    }
+
     try {
       kafkaMonitor.deleteTopic(topicName);
       return "redirect:/";

--- a/src/main/resources/templates/topic-detail.ftl
+++ b/src/main/resources/templates/topic-detail.ftl
@@ -41,10 +41,14 @@
 </#if>
 
 <div id="action-bar" class="container pl-0">
-    <a id="topic-messages" class="btn btn-outline-light" href="<@spring.url '/topic/${topic.name}/messages'/>"><i class="fa fa-eye"></i> View Messages</a>
-    <form id="delete-topic-form" action="<@spring.url '/topic/${topic.name}/delete'/>" method="POST">
-        <button class="btn btn-danger" type="submit"><i class="fa fa-remove"></i> Delete topic</button>
-    </form>
+    <a id="topic-messages" class="btn btn-outline-light" href="<@spring.url '/topic/${topic.name}/messages'/>">
+        <i class="fa fa-eye"></i> View Messages
+    </a>
+    <#if topicDeleteEnabled>
+        <form id="delete-topic-form" action="<@spring.url '/topic/${topic.name}/delete'/>" method="POST">
+            <button class="btn btn-danger" type="submit"><i class="fa fa-remove"></i> Delete topic</button>
+        </form>
+    </#if>
 </div>
 <br/>
 <div class="container-fluid pl-0">


### PR DESCRIPTION
Don't show the Delete topic button when --topic.deleteEnabled=false
The button is visible by default, no --topic.deleteEnabled is required
The flag is also checked in POST /delete request