### PR TITLE
Reduce number of calls to Kafka

### DIFF
--- a/src/main/java/kafdrop/controller/BrokerController.java
+++ b/src/main/java/kafdrop/controller/BrokerController.java
@@ -40,7 +40,7 @@ public final class BrokerController {
   public String brokerDetails(@PathVariable("id") int brokerId, Model model) {
     model.addAttribute("broker", kafkaMonitor.getBroker(brokerId)
         .orElseThrow(() -> new BrokerNotFoundException("No such broker " + brokerId)));
-    model.addAttribute("topics", kafkaMonitor.getTopics());
+    model.addAttribute("topics", kafkaMonitor.getTopics(TopicEnrichMode.TopicConfig));
     return "broker-detail";
   }
 

--- a/src/main/java/kafdrop/controller/ClusterController.java
+++ b/src/main/java/kafdrop/controller/ClusterController.java
@@ -64,7 +64,7 @@ public final class ClusterController {
     model.addAttribute("buildProperties", buildProperties);
 
     final var brokers = kafkaMonitor.getBrokers();
-    final var topics = kafkaMonitor.getTopics();
+    final var topics = kafkaMonitor.getTopics(TopicEnrichMode.TopicConfig);
     final var clusterSummary = kafkaMonitor.getClusterSummary(topics);
 
     final var missingBrokerIds = clusterSummary.getExpectedBrokerIds().stream()
@@ -91,7 +91,7 @@ public final class ClusterController {
   public @ResponseBody ClusterInfoVO getCluster() {
     final var vo = new ClusterInfoVO();
     vo.brokers = kafkaMonitor.getBrokers();
-    vo.topics = kafkaMonitor.getTopics();
+    vo.topics = kafkaMonitor.getTopics(TopicEnrichMode.TopicConfig);
     vo.summary = kafkaMonitor.getClusterSummary(vo.topics);
     return vo;
   }

--- a/src/main/java/kafdrop/controller/ConsumerController.java
+++ b/src/main/java/kafdrop/controller/ConsumerController.java
@@ -37,7 +37,7 @@ public final class ConsumerController {
 
   @RequestMapping("/{groupId:.+}")
   public String consumerDetail(@PathVariable("groupId") String groupId, Model model) throws ConsumerNotFoundException {
-    final var topicVos = kafkaMonitor.getTopics();
+    final var topicVos = kafkaMonitor.getTopics(TopicEnrichMode.PartitionSize);
     final var consumer = kafkaMonitor.getConsumers(topicVos)
         .stream()
         .filter(c -> c.getGroupId().equals(groupId))
@@ -53,7 +53,7 @@ public final class ConsumerController {
   })
   @RequestMapping(path = "/{groupId:.+}", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
   public @ResponseBody ConsumerVO getConsumer(@PathVariable("groupId") String groupId) throws ConsumerNotFoundException {
-    final var topicVos = kafkaMonitor.getTopics();
+    final var topicVos = kafkaMonitor.getTopics(TopicEnrichMode.PartitionSize);
     final var consumer = kafkaMonitor.getConsumers(topicVos)
         .stream()
         .filter(c -> c.getGroupId().equals(groupId))

--- a/src/main/java/kafdrop/controller/MessageController.java
+++ b/src/main/java/kafdrop/controller/MessageController.java
@@ -28,6 +28,7 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
+import kafdrop.service.TopicEnrichMode;
 import kafdrop.util.*;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
@@ -94,7 +95,7 @@ public final class MessageController {
     final int size = (count != null? count : 100);
     final MessageFormat defaultFormat = messageFormatProperties.getFormat();
     final MessageFormat defaultKeyFormat = keyFormatProperties.getFormat();
-    final TopicVO topic = kafkaMonitor.getTopic(topicName)
+    final TopicVO topic = kafkaMonitor.getTopic(topicName, TopicEnrichMode.PartitionSize)
         .orElseThrow(() -> new TopicNotFoundException(topicName));
 
     model.addAttribute("topic", topic);
@@ -151,7 +152,7 @@ public final class MessageController {
       model.addAttribute("messageForm", defaultForm);
     }
 
-    final TopicVO topic = kafkaMonitor.getTopic(topicName)
+    final TopicVO topic = kafkaMonitor.getTopic(topicName, TopicEnrichMode.PartitionSize)
         .orElseThrow(() -> new TopicNotFoundException(topicName));
     model.addAttribute("topic", topic);
 
@@ -224,7 +225,7 @@ public final class MessageController {
       @RequestParam(name = "msgTypeName", required = false) String msgTypeName
   ) {
     if (partition == null || offset == null || count == null) {
-      final TopicVO topic = kafkaMonitor.getTopic(topicName)
+      final TopicVO topic = kafkaMonitor.getTopic(topicName, TopicEnrichMode.PartitionSize)
           .orElseThrow(() -> new TopicNotFoundException(topicName));
 
       List<Object> partitionList = new ArrayList<>();

--- a/src/main/java/kafdrop/controller/TopicController.java
+++ b/src/main/java/kafdrop/controller/TopicController.java
@@ -31,6 +31,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.*;
 
+import static kafdrop.service.KafkaMonitor.ALL_TOPIC_ENRICH_MODES;
+
 /**
  * Handles requests for the topic page.
  */
@@ -49,7 +51,7 @@ public final class TopicController {
 
   @RequestMapping("/{name:.+}")
   public String topicDetails(@PathVariable("name") String topicName, Model model) {
-    final var topic = kafkaMonitor.getTopic(topicName)
+    final var topic = kafkaMonitor.getTopic(topicName, ALL_TOPIC_ENRICH_MODES)
         .orElseThrow(() -> new TopicNotFoundException(topicName));
     model.addAttribute("topic", topic);
     model.addAttribute("consumers", kafkaMonitor.getConsumers(Collections.singleton(topic)));
@@ -92,7 +94,7 @@ public final class TopicController {
   })
   @RequestMapping(path = "/{name:.+}", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
   public @ResponseBody TopicVO getTopic(@PathVariable("name") String topicName) {
-    return kafkaMonitor.getTopic(topicName)
+    return kafkaMonitor.getTopic(topicName, ALL_TOPIC_ENRICH_MODES)
         .orElseThrow(() -> new TopicNotFoundException(topicName));
   }
 
@@ -102,7 +104,7 @@ public final class TopicController {
   })
   @RequestMapping(produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
   public @ResponseBody List<TopicVO> getAllTopics() {
-    return kafkaMonitor.getTopics();
+    return kafkaMonitor.getTopics(TopicEnrichMode.TopicConfig);
   }
 
   @ApiOperation(value = "getConsumers", notes = "Get consumers for a topic")
@@ -112,7 +114,7 @@ public final class TopicController {
   })
   @RequestMapping(path = "/{name:.+}/consumers", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
   public @ResponseBody List<ConsumerVO> getConsumers(@PathVariable("name") String topicName) {
-    final var topic = kafkaMonitor.getTopic(topicName)
+    final var topic = kafkaMonitor.getTopic(topicName, TopicEnrichMode.PartitionSize)
         .orElseThrow(() -> new TopicNotFoundException(topicName));
     return kafkaMonitor.getConsumers(Collections.singleton(topic));
   }

--- a/src/main/java/kafdrop/service/KafkaMonitor.java
+++ b/src/main/java/kafdrop/service/KafkaMonitor.java
@@ -25,11 +25,16 @@ import org.apache.kafka.common.*;
 import java.util.*;
 
 public interface KafkaMonitor {
+  TopicEnrichMode[] ALL_TOPIC_ENRICH_MODES = new TopicEnrichMode[]{
+          TopicEnrichMode.PartitionSize,
+          TopicEnrichMode.TopicConfig
+  };
+
   List<BrokerVO> getBrokers();
 
   Optional<BrokerVO> getBroker(int id);
 
-  List<TopicVO> getTopics();
+  List<TopicVO> getTopics(TopicEnrichMode... topicEnrichModes);
 
   /**
    * Returns messages for a given topic.
@@ -40,7 +45,7 @@ public interface KafkaMonitor {
   List<MessageVO> getMessages(TopicPartition topicPartition, long offset, int count,
                               Deserializers deserializers);
 
-  Optional<TopicVO> getTopic(String topic);
+  Optional<TopicVO> getTopic(String topic, TopicEnrichMode... topicEnrichModes);
 
   ClusterSummaryVO getClusterSummary(Collection<TopicVO> topics);
 

--- a/src/main/java/kafdrop/service/TopicEnrichMode.java
+++ b/src/main/java/kafdrop/service/TopicEnrichMode.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Kafdrop contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package kafdrop.service;
+
+public enum TopicEnrichMode {
+    /**
+     * Specifies to enrich topic info with partition size (first offset, last offset and size).
+     */
+    PartitionSize,
+
+    /**
+     * Specifies to enrich topic info with topic configuration.
+     */
+    TopicConfig
+}


### PR DESCRIPTION
Kafdrop uses a heavy topic info object in all cases, even if additional data is not needed on UI side. It is proposed to add the ability to manage enrichment of the topic info object using the following modes:
* `PartitionSize` - specifies to enrich topic info with partition size (first offset, last offset and size)
* `TopicConfig` - specifies to enrich topic info with topic configuration

These changes are based on the following assumptions:
* `cluster-overview` and `broker-detail` views do not need data about size of partitions
* `message-inspector` and `consumer-detail` views do not need data about topic configuration