### PR TITLE
Updated the paths for .js and .css to not be absolute paths 

### DIFF
--- a/src/main/resources/templates/acl-overview.ftl
+++ b/src/main/resources/templates/acl-overview.ftl
@@ -27,7 +27,7 @@
     </style>
 </@template.header>
 
-<script src="<@spring.url '/js/powerFilter.js'/>"></script>
+<script src="<@spring.url './js/powerFilter.js'/>"></script>
 
 <#setting number_format="0">
 

--- a/src/main/resources/templates/cluster-overview.ftl
+++ b/src/main/resources/templates/cluster-overview.ftl
@@ -17,7 +17,7 @@
 <#import "lib/template.ftl" as template>
 <@template.header "Broker List"/>
 
-<script src="<@spring.url '/js/powerFilter.js'/>"></script>
+<script src="<@spring.url './js/powerFilter.js'/>"></script>
 
 
 <#setting number_format="0">

--- a/src/main/resources/templates/lib/template.ftl
+++ b/src/main/resources/templates/lib/template.ftl
@@ -19,15 +19,15 @@
 <html>
 <head>
     <title>Kafdrop: ${title}</title>
-    <link type="text/css" rel="stylesheet" href="<@spring.url '/css/bootstrap.min.css'/>"/>
-    <link type="text/css" rel="stylesheet" href="<@spring.url '/css/font-awesome.min.css'/>"/>
-    <link type="text/css" rel="stylesheet" href="<@spring.url '/css/global.css'/>"/>
+    <link type="text/css" rel="stylesheet" href="<@spring.url './css/bootstrap.min.css'/>"/>
+    <link type="text/css" rel="stylesheet" href="<@spring.url './css/font-awesome.min.css'/>"/>
+    <link type="text/css" rel="stylesheet" href="<@spring.url './css/global.css'/>"/>
 
-    <script src="<@spring.url '/js/jquery.min.js'/>"></script>
-    <script src="<@spring.url '/js/popper.min.js'/>"></script>
-    <script src="<@spring.url '/js/bootstrap.min.js'/>"></script>
-    <script src="<@spring.url '/js/global.js'/>"></script>
-    <script async defer src="<@spring.url '/js/github-buttons.js'/>"></script>
+    <script src="<@spring.url './js/jquery.min.js'/>"></script>
+    <script src="<@spring.url './js/popper.min.js'/>"></script>
+    <script src="<@spring.url './js/bootstrap.min.js'/>"></script>
+    <script src="<@spring.url './js/global.js'/>"></script>
+    <script async defer src="<@spring.url './js/github-buttons.js'/>"></script>
 
     <#nested>
 </head>

--- a/src/main/resources/templates/message-inspector.ftl
+++ b/src/main/resources/templates/message-inspector.ftl
@@ -39,7 +39,7 @@
         }
     </style>
 
-    <script src="<@spring.url '/js/message-inspector.js'/>"></script>
+    <script src="<@spring.url './js/message-inspector.js'/>"></script>
     
     <script type="text/javascript">
 	$( document ).ready(updateProtobufPanel);

--- a/src/main/resources/templates/topic-create.ftl
+++ b/src/main/resources/templates/topic-create.ftl
@@ -17,7 +17,7 @@
 <#import "lib/template.ftl" as template>
 <@template.header "Topic create"/>
 
-<script src="<@spring.url '/js/powerFilter.js'/>"></script>
+<script src="<@spring.url './js/powerFilter.js'/>"></script>
 
 
 <#setting number_format="0">

--- a/src/main/resources/templates/topic-messages.ftl
+++ b/src/main/resources/templates/topic-messages.ftl
@@ -28,7 +28,7 @@
             float: left;
         }
     </style>
-    <script src="<@spring.url '/js/message-inspector.js'/>"></script>
+    <script src="<@spring.url './js/message-inspector.js'/>"></script>
 </@template.header>
 <#setting number_format="0">
 


### PR DESCRIPTION
This makes it possible for the paths to be found behind a reverse proxy. As right now if a webserver takes care of the url paths and puts kafdrop some place else than /, kafdrop will not be able to find the .css and .js files as it uses absolute paths /js and /css.
By switching over to ./js and ./css, kafdrop will be able to handle paths behind a reverse proxy.