### PR TITLE
add missing default key in values

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
           - name: SERVER_PORT
             value: "{{ .Values.server.port }}"
           - name: CMD_ARGS
-{{- if .Values.mountProtoDesc }}
+{{- if .Values.mountProtoDesc.enabled }}
             value: "--message.format=PROTOBUF --protobufdesc.directory=/protodesc/ {{ .Values.cmdArgs }}"
 {{- else }}
             value: "{{ .Values.cmdArgs }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -59,3 +59,7 @@ tolerations: []
 affinity: {}
 
 podAnnotations: {}
+
+mountProtoDesc: 
+  enabled: false
+  hostPath:


### PR DESCRIPTION
This fixes #141 by adding the missing map default in the values file for the changes made to `deployment.yaml` in 94be471c308d8c8cd43eb2615a4ba7d7db08bd86.

With this the chart passes the helm linter.