### PR TITLE
[Docker] Allow base64 for certain Input

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Language grade: Java](https://img.shields.io/lgtm/grade/java/g/obsidiandynamics/kafdrop.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/obsidiandynamics/kafdrop/context:java)
 
 
-<em>Kafdrop is a web UI for viewing Kafka topics and browsing consumer groups.</em> The tool displays information such as brokers, topics, partitions, consumers, and lets you view messages. 
+<em>Kafdrop is a web UI for viewing Kafka topics and browsing consumer groups.</em> The tool displays information such as brokers, topics, partitions, consumers, and lets you view messages.
 
 ![Overview Screenshot](docs/images/overview.png?raw=true)
 
@@ -63,7 +63,7 @@ Finally, a default message format (e.g. to deserialize Avro messages) can option
 Valid format values are `DEFAULT`, `AVRO`, `PROTOBUF`. This can also be configured at the topic level via dropdown when viewing messages.
 
 ## Configure Protobuf message type
-In case of protobuf message type, the definition of a message could be compiled and transmitted using a descriptor file. Thus, in order for kafdrop to recognize the message, the application will need to access to the descriptor file(s). Kafdrop will allow user to select descriptor and well as specifying name of one of the message type provided by the descriptor at runtime. 
+In case of protobuf message type, the definition of a message could be compiled and transmitted using a descriptor file. Thus, in order for kafdrop to recognize the message, the application will need to access to the descriptor file(s). Kafdrop will allow user to select descriptor and well as specifying name of one of the message type provided by the descriptor at runtime.
 
 To configure a folder with protobuf descriptor file(s) (.desc), follow:
 ```
@@ -248,10 +248,11 @@ docker run -d --rm -p 9000:9000 \
 |`KAFKA_PROPERTIES`     |Additional properties to configure the broker connection (base-64 encoded).
 |`KAFKA_TRUSTSTORE`     |Certificate for broker authentication (base-64 encoded). Required for TLS/SSL.
 |`KAFKA_KEYSTORE`       |Private key for mutual TLS authentication (base-64 encoded).
+|`BASE64_INPUT`         |Disable base64 decryption for `KAFKA_TRUSTSTORE`, `KAFKA_KEYSTORE` and `KAFKA_PROPERTIES` by setting `false` as value. Base64 decryption is enabled by default.
 |`SERVER_SERVLET_CONTEXTPATH`|The context path to serve requests on (must end with a `/`). Defaults to `/`.
 |`SERVER_PORT`          |The web server port to listen on. Defaults to `9000`.
 |`SCHEMAREGISTRY_CONNECT `|The endpoint of Schema Registry for Avro message
-|`CMD_ARGS`             |Command line arguments to Kafdrop, e.g. `--message.format` or `--protobufdesc.directory` or `--server.port`. 
+|`CMD_ARGS`             |Command line arguments to Kafdrop, e.g. `--message.format` or `--protobufdesc.directory` or `--server.port`.
 
 ##### Advanced configuration
 |Name                   |Description
@@ -299,7 +300,7 @@ Add a logout page in `/usr/local/opt/nginx/html/401.html`:
 Use the following snippet for `/usr/local/etc/nginx/nginx.conf`:
 ```
 worker_processes 4;
-  
+
 events {
   worker_connections 1024;
 }

--- a/src/main/docker/kafdrop.sh
+++ b/src/main/docker/kafdrop.sh
@@ -25,6 +25,9 @@ if [ $MARATHON_APP_RESOURCE_MEM ]; then
     HEAP_ARGS="-Xms${MARATHON_APP_RESOURCE_MEM%.*}m -Xmx${MARATHON_APP_RESOURCE_MEM%.*}m"
 fi
 
+# Allows non base64 input
+BASE64_INPUT="${BASE64_INPUT:-true}"
+
 if [ $JMX_PORT ]; then
     JMX_ARGS="-Dcom.sun.management.jmxremote \
     -Dcom.sun.management.jmxremote.port=${JMX_PORT} \
@@ -38,7 +41,11 @@ fi
 KAFKA_PROPERTIES_FILE=${KAFKA_PROPERTIES_FILE:-kafka.properties}
 if [ "$KAFKA_PROPERTIES" != "" ]; then
   echo Writing Kafka properties into $KAFKA_PROPERTIES_FILE
-  echo "$KAFKA_PROPERTIES" | base64 --decode --ignore-garbage > $KAFKA_PROPERTIES_FILE
+  if ${BASE64_INPUT}; then
+    echo "$KAFKA_PROPERTIES" | base64 --decode --ignore-garbage > $KAFKA_PROPERTIES_FILE
+  else
+    echo "$KAFKA_PROPERTIES" > $KAFKA_PROPERTIES_FILE
+  fi
 else
   rm $KAFKA_PROPERTIES_FILE |& > /dev/null | true
 fi
@@ -46,7 +53,11 @@ fi
 KAFKA_TRUSTSTORE_FILE=${KAFKA_TRUSTSTORE_FILE:-kafka.truststore.jks}
 if [ "$KAFKA_TRUSTSTORE" != "" ]; then
   echo Writing Kafka truststore into $KAFKA_TRUSTSTORE_FILE
-  echo "$KAFKA_TRUSTSTORE" | base64 --decode --ignore-garbage > $KAFKA_TRUSTSTORE_FILE
+  if ${BASE64_INPUT}; then
+    echo "$KAFKA_TRUSTSTORE" | base64 --decode --ignore-garbage > $KAFKA_TRUSTSTORE_FILE
+  else
+    echo "$KAFKA_TRUSTSTORE" > $KAFKA_TRUSTSTORE_FILE
+  fi
 else
   rm $KAFKA_TRUSTSTORE_FILE |& > /dev/null | true
 fi
@@ -54,7 +65,11 @@ fi
 KAFKA_KEYSTORE_FILE=${KAFKA_KEYSTORE_FILE:-kafka.keystore.jks}
 if [ "$KAFKA_KEYSTORE" != "" ]; then
   echo Writing Kafka keystore into $KAFKA_KEYSTORE_FILE
-  echo "$KAFKA_KEYSTORE" | base64 --decode --ignore-garbage > $KAFKA_KEYSTORE_FILE
+  if ${BASE64_INPUT}; then
+    echo "$KAFKA_KEYSTORE" | base64 --decode --ignore-garbage > $KAFKA_KEYSTORE_FILE
+  else
+    echo "$KAFKA_KEYSTORE" > $KAFKA_KEYSTORE_FILE
+  fi
 else
   rm $KAFKA_KEYSTORE_FILE |& > /dev/null | true
 fi


### PR DESCRIPTION
**Changes**
In this PR I added an Environment variable to the kafdrop.sh Entryscript. This allows to disable the base64 decryption for `KAFKA_TRUSTSTORE`, `KAFKA_KEYSTORE` and `KAFKA_PROPERTIES`. By this the possibility is created to input the values raw and not base64 encrypted. This change is backwardes compatible, since you manually have to set the variable for it to take affect. By defining the `BASE64_INPUT` environment variable as `false`, the decryption mechanism is disabled.

**Motivation/Problem**
You might think this change is useless, since it lowers the security. I am contributing this change regarding kubernetes compatibility. In an improved helm chart version (which I will contribute as well soon) values for the fields `KAFKA_TRUSTSTORE`, `KAFKA_KEYSTORE` and `KAFKA_PROPERTIES` are stored in a generated secret or an existing secret is referenced. Then the Environment variable is referenced to the secret and Kubernetes will decrypt it within the pod (Read more: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables). Since the decryption is already done by kubernetes, this switch is needed within the startup script.

**Testing**
I have made the testing very simple. I have recreated the image with the changes proposed in this PR. The testing is all done with different Environment variables. I have used very simple values to test this (Simple sasl conneector). These look like this:

```
sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='suchUser' password='veryS3CRET';
security.protocol=SASL_PLAINTEXT
sasl.mechanism=PLAIN`
```

**Base Encrypted** 
This still works, as it works now:

```
---
version: "2"
services:
  kafdrop:
    image: obsidiandynamics/kafdrop
    restart: "no"
    ports:
      - "9000:9000"
    environment:
      KAFKA_BROKERCONNECT: "localhost:9200"
      JVM_OPTS: "-Xms16M -Xmx48M -Xss180K -XX:-TieredCompilation -XX:+UseStringDeduplication -noverify"
     # The above input base64 encrypted
      KAFKA_PROPERTIES: "c2FzbC5qYWFzLmNvbmZpZz1vcmcuYXBhY2hlLmthZmthLmNvbW1vbi5zZWN1cml0eS5wbGFpbi5QbGFpbkxvZ2luTW9kdWxlIHJlcXVpcmVkIHVzZXJuYW1lPSdzdWNoVXNlcicgcGFzc3dvcmQ9J3ZlcnlTM0NSRVQnOwpzZWN1cml0eS5wcm90b2NvbD1TQVNMX1BMQUlOVEVYVApzYXNsLm1lY2hhbmlzbT1QTEFJTgo="
```

**Not Base64 Encrypted**
New, this will work as well:

```
---
version: "2"
services:
  kafdrop:
    image: obsidiandynamics/kafdrop
    restart: "no"
    ports:
      - "9000:9000"
    environment:
      KAFKA_BROKERCONNECT: "localhost:9200"
      JVM_OPTS: "-Xms16M -Xmx48M -Xss180K -XX:-TieredCompilation -XX:+UseStringDeduplication -noverify"
      BASE64_INPUT: "false"
      KAFKA_PROPERTIES: "sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='suchUser' password='veryS3CRET';\nsecurity.protocol=SASL_PLAINTEXT\nsasl.mechanism=PLAIN"
```
If there's any reason this shouldn't be implemented, let me know. But i see it as a nice little feature =).
