### PR TITLE
Add test containers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <additionalOptions>-Xdoclint:none</additionalOptions>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <protobuf.version>3.11.1</protobuf.version>
+        <testcontainers.version>1.14.3</testcontainers.version>
     </properties>
 
     <scm>
@@ -177,6 +178,34 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- Spring test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Testcontainers -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/kafdrop/Kafdrop.java
+++ b/src/main/java/kafdrop/Kafdrop.java
@@ -46,13 +46,17 @@ public class Kafdrop {
   private final static Logger LOG = LoggerFactory.getLogger(Kafdrop.class);
 
   public static void main(String[] args) {
-    new SpringApplicationBuilder(Kafdrop.class)
-        .bannerMode(Mode.OFF)
-        .listeners(new EnvironmentSetupListener(),
-                   new LoggingConfigurationListener())
-        .run(args);
+    createApplicationBuilder()
+      .run(args);
   }
-  
+
+  public static SpringApplicationBuilder createApplicationBuilder() {
+    return new SpringApplicationBuilder(Kafdrop.class)
+      .bannerMode(Mode.OFF)
+      .listeners(new EnvironmentSetupListener(),
+              new LoggingConfigurationListener());
+  }
+
   @Bean
   public WebServerFactoryCustomizer<UndertowServletWebServerFactory> deploymentCustomizer() {
     return factory -> {

--- a/src/test/java/kafdrop/AbstractIntegrationTest.java
+++ b/src/test/java/kafdrop/AbstractIntegrationTest.java
@@ -1,0 +1,37 @@
+package kafdrop;
+
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.lifecycle.Startables;
+
+import java.util.List;
+import java.util.Map;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ContextConfiguration(initializers = AbstractIntegrationTest.Initializer.class)
+abstract class AbstractIntegrationTest {
+    static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+        static KafkaContainer kafka = new KafkaContainer();
+
+        public static Map<String, String> getProperties() {
+            Startables.deepStart(List.of(kafka)).join();
+            return Map.of("kafka.brokerConnect", kafka.getBootstrapServers());
+        }
+
+        @Override
+        @SuppressWarnings("unchecked, rawtypes")
+        public void initialize(ConfigurableApplicationContext context) {
+            var env = context.getEnvironment();
+            env.getPropertySources().addFirst(new MapPropertySource(
+                    "testcontainers", (Map) getProperties()
+            ));
+        }
+    }
+}

--- a/src/test/java/kafdrop/KafdropTest.java
+++ b/src/test/java/kafdrop/KafdropTest.java
@@ -1,0 +1,8 @@
+package kafdrop;
+
+import org.junit.Test;
+
+public class KafdropTest extends AbstractIntegrationTest {
+    @Test
+    public void contextTest(){}
+}

--- a/src/test/java/kafdrop/LocalRunner.java
+++ b/src/test/java/kafdrop/LocalRunner.java
@@ -1,0 +1,13 @@
+package kafdrop;
+
+/**
+ * Use this class for local development.
+ * It will run local kafka in docker with test containers.
+ */
+public class LocalRunner {
+    public static void main(String[] args) {
+        Kafdrop.createApplicationBuilder()
+                .initializers(new AbstractIntegrationTest.Initializer())
+                .run(args);
+    }
+}


### PR DESCRIPTION
As already mentinoed in https://github.com/obsidiandynamics/kafdrop/issues/111, I think it's quite useful to integrate test containres to Kafdrop.

First, it alows to write integration tests and run them localy or via CI.

Second, it alows much easier development expereince. You don't need to run docker-compose and control it current state. You can just run your test and test containers will controll it lyfe cycle.

PR includes AbstractIntegrationTest which is base abstract class for integration test, basic context load test and LocalRuner for local development.