### PR TITLE
Add support for protobuf delimited encoding

### DIFF
--- a/src/main/resources/templates/message-inspector.ftl
+++ b/src/main/resources/templates/message-inspector.ftl
@@ -49,11 +49,13 @@
 	    {
 	        $('#protobufDescriptor').hide();
 	        $('#protobufMsgType').hide();
+	        $('#protobufIsDelimited').hide();
 	    }
 	    else
 	    {
 	        $('#protobufDescriptor').show();
 	        $('#protobufMsgType').show();
+	        $('#protobufIsDelimited').show();
 	        $('#descFile').prop('required',true);
 	    }
 	}  
@@ -146,6 +148,13 @@
             <#if descFiles?size != 0>
               <label class=control-label" for="format">Protobuf message type name</label>
               <@spring.formInput path="messageForm.msgTypeName" attributes='class="form-control"'/>
+            </#if>
+        </div>
+        &nbsp;&nbsp;
+        <div class="form-group" id="protobufIsDelimited">
+            <#if descFiles?size != 0>
+              <label class=control-label" for="isDelimited">Protobuf delimited encoding</label>
+              <@spring.formCheckbox path="messageForm.isDelimited" attributes='class="form-control"'/>
             </#if>
         </div>
         &nbsp;&nbsp;


### PR DESCRIPTION
Protobuf delimited encoding (as implemented in `com.google.protobuf.Message.writeDelimitedTo`) is widely used and required by certain Kafka integrations (e.g., clickhouse). This pool request adds support for this encoding. Specifically, it adds a checkbox next to the protobuf descriptor and message type fields that enables this encoding.