### PR TITLE
Update version of kafka-avro-serializer (#167)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
-            <version>5.2.2</version>
+            <version>5.5.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Update version of kafka-avro-serializer to support schema references as described in https://docs.confluent.io/current/schema-registry/serdes-develop/index.html#referenced-schemas (https://github.com/obsidiandynamics/kafdrop/issues/167).