### PR TITLE
Use getFullName instead of getName to take namespace

### DIFF
--- a/src/main/java/kafdrop/util/ProtobufMessageDeserializer.java
+++ b/src/main/java/kafdrop/util/ProtobufMessageDeserializer.java
@@ -57,7 +57,7 @@ public class ProtobufMessageDeserializer implements MessageDeserializer {
 
       final var descriptors = descs.stream().flatMap(desc -> desc.getMessageTypes().stream()).collect(Collectors.toList());
 
-      final var messageDescriptor = descriptors.stream().filter(desc -> msgTypeName.equals(desc.getName())).findFirst();
+      final var messageDescriptor = descriptors.stream().filter(desc -> msgTypeName.equals(desc.getFullName())).findFirst();
       if (messageDescriptor.isEmpty()) {
         final String errorMsg = "Can't find specific message type: " + msgTypeName;
         LOG.error(errorMsg);


### PR DESCRIPTION
Protobuf allows method getFullName to get the type's fully-qualified name. This is especially helpful considering cases where we have namespace in our protobuf descriptor 