### PR TITLE
Support passing protobuf descriptor to values.yaml besides mounting hostpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Navigate to [http://localhost:8001/api/v1/namespaces/default/services/http:kafdr
 
 
 ### Protobuf support via helm chart:
+
 To install with protobuf support, a "facility" option is provided for the deployment, to mount the descriptor files folder, as well as passing the required CMD arguments, via option _mountProtoDesc_.
 Example:
 
@@ -142,6 +143,21 @@ helm upgrade -i kafdrop chart --set image.tag=3.x.x \
     --set mountProtoDesc.hostPath="<path/to/desc/folder>" \
     --set jvm.opts="-Xms32M -Xmx64M"
 ```
+
+#### Pass protobuf descriptor
+On some platform or in some automated deployment model, mounting protodesc with a path is not possible due to the deployment has no access to the node's hostpath or one cant simply upload the protodesc file to the hostpath. In such case, we can pass the Base64 encoded value of proto.desc to the deployment in values.yaml. For example:
+
+```yaml
+# in values.yaml
+mountProtoDesc:
+  enabled: true
+  descFiles:
+    proto.desc: |-
+      CrIDCjFsaWIva2Fma2FfcHJvdG8va2V5cGF5L3dlYmhvb2svbm90aWZpY2F0aW9u
+      LnByb3RvEhprYWZrYV9wcm90by5rZXlwYXkud2ViaG9vayLYAgoMTm90aWZpY2F0
+```
+
+With this, the chart will create a secret file containing proto desc and the deployment can mount to this file later.
 
 ## Building
 After cloning the repository, building is just a matter of running a standard Maven build:

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Navigate to [http://localhost:8001/api/v1/namespaces/default/services/http:kafdr
 
 ### Protobuf support via helm chart:
 
+#### Via custom mount path
 To install with protobuf support, a "facility" option is provided for the deployment, to mount the descriptor files folder, as well as passing the required CMD arguments, via option _mountProtoDesc_.
 Example:
 
@@ -144,7 +145,7 @@ helm upgrade -i kafdrop chart --set image.tag=3.x.x \
     --set jvm.opts="-Xms32M -Xmx64M"
 ```
 
-#### Pass protobuf descriptor
+#### Via passing protobuf descriptor file content
 On some platform or in some automated deployment model, mounting protodesc with a path is not possible due to the deployment has no access to the node's hostpath or one cant simply upload the protodesc file to the hostpath. In such case, we can pass the Base64 encoded value of proto.desc to the deployment in values.yaml. For example:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ mountProtoDesc:
 
 With this, the chart will create a secret file containing proto desc and the deployment can mount to this file later.
 
+*Why do we have to base64 encode proto.desc?*
+- Because passing binary files into values.yaml will cause error converting YAML to JSON: control characters not allowed.
+
+*Why is proto.desc a secret, not configmap?*
+- Theoretically, configmap is the default way for such kind of data. However, in practice, when helm works on the template, it will have to decode the base64 encoded proto.desc to pass into configmap, which later cause YAML to contain invalid octet. Therefore, passing it to a k8s secret resource will delegate the decoding job to runtime, when the deployment needs to know the content of the file.  
+
 ## Building
 After cloning the repository, building is just a matter of running a standard Maven build:
 ```sh

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.mountProtoDesc.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "chart.name" . }}
+    helm.sh/chart: {{ include "chart.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  name: {{ template "chart.fullname" . }}
+data:
+{{- range $key, $value := .Values.mountProtoDesc.descFiles }}
+  {{- if $key | regexMatch ".*\\.desc$" }}
+  {{ $key }}: |
+{{ $value | default "{}" | b64enc | indent 4 }}
+  {{- end }}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       annotations:
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
-{{- end }}        
+{{- end }}
     spec:
       containers:
         - name: {{ .Chart.Name }}
@@ -57,7 +57,7 @@ spec:
   {{- if .Values.mountProtoDesc.hostPath }}
             value: "--message.format=PROTOBUF --protobufdesc.directory=/protodesc/ {{ .Values.cmdArgs }}"
   {{- else }}
-            value: "--message.format=PROTOBUF --protobufdesc.directory=/etc/config-volume"
+            value: "--message.format=PROTOBUF --protobufdesc.directory=/etc/protodesc-volume"
   {{- end }}
 {{- else }}
             value: "{{ .Values.cmdArgs }}"
@@ -107,12 +107,13 @@ spec:
             type: directory
   {{- else }}
           volumeMounts:
-            - mountPath: /etc/config
-              name: config-volume
+            - mountPath: /etc/protodesc-volume
+              name: protodesc-volume
+              readOnly: true
       volumes:
-        - name: config-volume
-          configMap:
-            name: {{ template "chart.fullname" . }}
+        - name: protodesc-volume
+          secret:
+            secretName: {{ template "chart.fullname" . }}
   {{- end }}
 {{- end }}
 

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -54,7 +54,11 @@ spec:
             value: "{{ .Values.server.port }}"
           - name: CMD_ARGS
 {{- if .Values.mountProtoDesc.enabled }}
+  {{- if .Values.mountProtoDesc.hostPath }}
             value: "--message.format=PROTOBUF --protobufdesc.directory=/protodesc/ {{ .Values.cmdArgs }}"
+  {{- else }}
+            value: "--message.format=PROTOBUF --protobufdesc.directory=/etc/config-volume"
+  {{- end }}
 {{- else }}
             value: "{{ .Values.cmdArgs }}"
 {{- end }}
@@ -92,14 +96,23 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
 {{- if .Values.mountProtoDesc.enabled }}
+  {{- if .Values.mountProtoDesc.hostPath }}
           volumeMounts:
             - mountPath: /protodesc/
               name: proto-desc
       volumes:
         - name: proto-desc
-          hostPath:
-            path: {{ .Values.mountProtoDesc.hostPath }}
-            type: Directory
+          hostpath:
+            path: {{ .values.mountProtoDesc.hostpath }}
+            type: directory
+  {{- else }}
+          volumeMounts:
+            - mountPath: /etc/config
+              name: config-volume
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ template "chart.fullname" . }}
+  {{- end }}
 {{- end }}
-
 

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.mountProtoDesc.enabled }}
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: {{ include "chart.name" . }}
@@ -8,11 +8,12 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   name: {{ template "chart.fullname" . }}
+type: Opaque
 data:
 {{- range $key, $value := .Values.mountProtoDesc.descFiles }}
   {{- if $key | regexMatch ".*\\.desc$" }}
   {{ $key }}: |
-{{ $value | default "{}" | b64enc | indent 4 }}
+{{ $value | default "{}" | indent 4 }}
   {{- end }}
 {{- end -}}
 {{- end -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -6,7 +6,7 @@ image:
   pullPolicy: Always
 
 kafka:
-  brokerConnect: localhost:9092
+  brokerConnect: 192.168.65.2:9092
   properties: ""
   truststore: ""
   keystore: ""
@@ -64,14 +64,13 @@ mountProtoDesc:
   enabled: true
   descFiles:
     proto.desc: |-
-      
-      +lib/kafka_proto/keypay/keypay.webhook.protoKafkaProto.Keypay.Webhook"â
-      NotificationData
-      id (Rid'
-      updated_section (	RupdatedSection3
-      pay_condition_rule_set (	RpayConditionRuleSet%
-      leave_template (	RleaveTemplate9
-      super_fund1_member_number (	RsuperFund1MemberNumber"e
-      Notification
-      event (	Revent?
-      data (2+.KafkaProto.Keypay.Webhook.NotificationDataRdatabproto3
+      CrIDCjFsaWIva2Fma2FfcHJvdG8va2V5cGF5L3dlYmhvb2svbm90aWZpY2F0aW9u
+      LnByb3RvEhprYWZrYV9wcm90by5rZXlwYXkud2ViaG9vayLYAgoMTm90aWZpY2F0
+      aW9uEhQKBWV2ZW50GAQgASgJUgVldmVudBJNCgRkYXRhGAUgASgLMjkua2Fma2Ff
+      cHJvdG8ua2V5cGF5LndlYmhvb2suTm90aWZpY2F0aW9uLk5vdGlmaWNhdGlvbkRh
+      dGFSBGRhdGEa4gEKEE5vdGlmaWNhdGlvbkRhdGESDgoCaWQYASABKANSAmlkEicK
+      D3VwZGF0ZWRfc2VjdGlvbhgCIAEoCVIOdXBkYXRlZFNlY3Rpb24SMwoWcGF5X2Nv
+      bmRpdGlvbl9ydWxlX3NldBgDIAEoCVITcGF5Q29uZGl0aW9uUnVsZVNldBIlCg5s
+      ZWF2ZV90ZW1wbGF0ZRgEIAEoCVINbGVhdmVUZW1wbGF0ZRI5ChlzdXBlcl9mdW5k
+      MV9tZW1iZXJfbnVtYmVyGAUgASgJUhZzdXBlckZ1bmQxTWVtYmVyTnVtYmVyYgZw
+      cm90bzM=

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -62,15 +62,17 @@ podAnnotations: {}
 
 mountProtoDesc:
   enabled: true
-  descFiles:
-    proto.desc: |-
-      CrIDCjFsaWIva2Fma2FfcHJvdG8va2V5cGF5L3dlYmhvb2svbm90aWZpY2F0aW9u
-      LnByb3RvEhprYWZrYV9wcm90by5rZXlwYXkud2ViaG9vayLYAgoMTm90aWZpY2F0
-      aW9uEhQKBWV2ZW50GAQgASgJUgVldmVudBJNCgRkYXRhGAUgASgLMjkua2Fma2Ff
-      cHJvdG8ua2V5cGF5LndlYmhvb2suTm90aWZpY2F0aW9uLk5vdGlmaWNhdGlvbkRh
-      dGFSBGRhdGEa4gEKEE5vdGlmaWNhdGlvbkRhdGESDgoCaWQYASABKANSAmlkEicK
-      D3VwZGF0ZWRfc2VjdGlvbhgCIAEoCVIOdXBkYXRlZFNlY3Rpb24SMwoWcGF5X2Nv
-      bmRpdGlvbl9ydWxlX3NldBgDIAEoCVITcGF5Q29uZGl0aW9uUnVsZVNldBIlCg5s
-      ZWF2ZV90ZW1wbGF0ZRgEIAEoCVINbGVhdmVUZW1wbGF0ZRI5ChlzdXBlcl9mdW5k
-      MV9tZW1iZXJfbnVtYmVyGAUgASgJUhZzdXBlckZ1bmQxTWVtYmVyTnVtYmVyYgZw
-      cm90bzM=
+  # either use hostPath or descFiles
+  hostPath:
+  # descFiles:
+    # proto.desc: |-
+    #   CrIDCjFsaWIva2Fma2FfcHJvdG8va2V5cGF5L3dlYmhvb2svbm90aWZpY2F0aW9u
+    #   LnByb3RvEhprYWZrYV9wcm90by5rZXlwYXkud2ViaG9vayLYAgoMTm90aWZpY2F0
+    #   aW9uEhQKBWV2ZW50GAQgASgJUgVldmVudBJNCgRkYXRhGAUgASgLMjkua2Fma2Ff
+    #   cHJvdG8ua2V5cGF5LndlYmhvb2suTm90aWZpY2F0aW9uLk5vdGlmaWNhdGlvbkRh
+    #   dGFSBGRhdGEa4gEKEE5vdGlmaWNhdGlvbkRhdGESDgoCaWQYASABKANSAmlkEicK
+    #   D3VwZGF0ZWRfc2VjdGlvbhgCIAEoCVIOdXBkYXRlZFNlY3Rpb24SMwoWcGF5X2Nv
+    #   bmRpdGlvbl9ydWxlX3NldBgDIAEoCVITcGF5Q29uZGl0aW9uUnVsZVNldBIlCg5s
+    #   ZWF2ZV90ZW1wbGF0ZRgEIAEoCVINbGVhdmVUZW1wbGF0ZRI5ChlzdXBlcl9mdW5k
+    #   MV9tZW1iZXJfbnVtYmVyGAUgASgJUhZzdXBlckZ1bmQxTWVtYmVyTnVtYmVyYgZw
+    #   cm90bzM=

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -60,6 +60,18 @@ affinity: {}
 
 podAnnotations: {}
 
-mountProtoDesc: 
-  enabled: false
-  hostPath:
+mountProtoDesc:
+  enabled: true
+  descFiles:
+    proto.desc: |-
+      
+      +lib/kafka_proto/keypay/keypay.webhook.protoKafkaProto.Keypay.Webhook"â
+      NotificationData
+      id (Rid'
+      updated_section (	RupdatedSection3
+      pay_condition_rule_set (	RpayConditionRuleSet%
+      leave_template (	RleaveTemplate9
+      super_fund1_member_number (	RsuperFund1MemberNumber"e
+      Notification
+      event (	Revent?
+      data (2+.KafkaProto.Keypay.Webhook.NotificationDataRdatabproto3

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -6,7 +6,7 @@ image:
   pullPolicy: Always
 
 kafka:
-  brokerConnect: 192.168.65.2:9092
+  brokerConnect: localhost:9092
   properties: ""
   truststore: ""
   keystore: ""


### PR DESCRIPTION
For motivations, please view the changes in readme.md

This PR add one k8s secret resource to help support protobuf where mounting a proto.desc file from host path is not an option. I also clarified why we have to go with k8s secret instead of configmap in readme. 
