### PR TITLE
avoid deleting configuration files

### DIFF
--- a/src/main/docker/kafdrop.sh
+++ b/src/main/docker/kafdrop.sh
@@ -39,24 +39,18 @@ KAFKA_PROPERTIES_FILE=${KAFKA_PROPERTIES_FILE:-kafka.properties}
 if [ "$KAFKA_PROPERTIES" != "" ]; then
   echo Writing Kafka properties into $KAFKA_PROPERTIES_FILE
   echo "$KAFKA_PROPERTIES" | base64 --decode --ignore-garbage > $KAFKA_PROPERTIES_FILE
-else
-  rm $KAFKA_PROPERTIES_FILE |& > /dev/null | true
 fi
 
 KAFKA_TRUSTSTORE_FILE=${KAFKA_TRUSTSTORE_FILE:-kafka.truststore.jks}
 if [ "$KAFKA_TRUSTSTORE" != "" ]; then
   echo Writing Kafka truststore into $KAFKA_TRUSTSTORE_FILE
   echo "$KAFKA_TRUSTSTORE" | base64 --decode --ignore-garbage > $KAFKA_TRUSTSTORE_FILE
-else
-  rm $KAFKA_TRUSTSTORE_FILE |& > /dev/null | true
 fi
 
 KAFKA_KEYSTORE_FILE=${KAFKA_KEYSTORE_FILE:-kafka.keystore.jks}
 if [ "$KAFKA_KEYSTORE" != "" ]; then
   echo Writing Kafka keystore into $KAFKA_KEYSTORE_FILE
   echo "$KAFKA_KEYSTORE" | base64 --decode --ignore-garbage > $KAFKA_KEYSTORE_FILE
-else
-  rm $KAFKA_KEYSTORE_FILE |& > /dev/null | true
 fi
 
 ARGS="--add-opens=java.base/sun.nio.ch=ALL-UNNAMED -Xss256K \


### PR DESCRIPTION
In case $KAFKA_PROPERTIES $KAFKA_TRUSTSTORE or $KAFKA_KEYSTORE exists,
they will overwrite its configuration file.
Deleting them if they are not present is preventing to prepare them directly.
For example by init container in kubernetes where I do need to pass passphrase from secret created by cert-manager.