### PR TITLE
Fixes #251

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <description>For when you have a Kafka cluster to monitor</description>
 
     <properties>
-        <spring.boot.version>2.2.10.RELEASE</spring.boot.version>
+        <spring.boot.version>2.2.13.RELEASE</spring.boot.version>
         <additionalparam>-Xdoclint:none</additionalparam>
 
         <!-- name of parameter changed in latest mvn javadoc plugin version-->
@@ -64,13 +64,13 @@
 		    <groupId>com.google.protobuf</groupId>
 		    <artifactId>protobuf-java</artifactId>
 		    <version>${protobuf.version}</version>
-		</dependency>		    
+		</dependency>
 		<!-- https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java-util -->
 		<dependency>
 		    <groupId>com.google.protobuf</groupId>
 		    <artifactId>protobuf-java-util</artifactId>
-		    <version>${protobuf.version}</version>		    
-		</dependency>	
+		    <version>${protobuf.version}</version>
+		</dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>


### PR DESCRIPTION
Updates spring-boot to 2.2.13, so that fixes for CVE-2020-5421 are included (https://tanzu.vmware.com/security/cve-2020-5421

I've created a draft PR, because master (or main) has moved onward to 3.28.0-SNAPSHOT.
I'd requested a patch release & I'm not sure what the process is (I imagine it'll entail creating a branch from `62662c6f2bceeecdc0619f63f7fec7e9a6e961b4`, updating the version in the pom & creating a new image) 
