### PR TITLE
Fixes #265. Update kafka-client to version 2.7.0 to support TLS v1.3.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <description>For when you have a Kafka cluster to monitor</description>
 
     <properties>
-        <spring.boot.version>2.2.10.RELEASE</spring.boot.version>
+        <spring.boot.version>2.3.10.RELEASE</spring.boot.version>
         <additionalparam>-Xdoclint:none</additionalparam>
 
         <!-- name of parameter changed in latest mvn javadoc plugin version-->
@@ -87,6 +87,11 @@
             <version>1.18.8</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>2.7.0</version>
+        </dependency>
+        <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
             <version>5.2.2</version>
@@ -144,6 +149,10 @@
                     <artifactId>spring-boot-starter-tomcat</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.kafka</groupId>


### PR DESCRIPTION
Update kafka-client to version 2.7.0 to support TLS v1.3. Upgrade Spring Boot to version 2.3.x to support Kafka clients >= 2.5.x. Added Spring Boot validation starter as that dependency no longer comes in via the web starter.