### PR TITLE
Added support for AWS MSK IAM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,13 @@
             <version>0.8.20</version>
         </dependency>
 
+        <!-- Support for AWS MSK IAM Auth-->
+        <dependency>
+            <groupId>software.amazon.msk</groupId>
+            <artifactId>aws-msk-iam-auth</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+
         <!-- Spring Boot -->
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
AWS announced support for a new SASL mechanism called AWS_MSK_IAM which enables to handle both authentication and authorisation with AWS IAM. I added the dependency on aws-msk-iam-auth to enable support for that mechanism.

More on that:
https://aws.amazon.com/blogs/big-data/securing-apache-kafka-is-easy-and-familiar-with-iam-access-control-for-amazon-msk/
