### PR TITLE
Add option for env variable for kafka_saslJaasConfig

### DIFF
--- a/src/main/java/kafdrop/config/KafkaConfiguration.java
+++ b/src/main/java/kafdrop/config/KafkaConfiguration.java
@@ -17,6 +17,7 @@ public final class KafkaConfiguration {
   private static final Logger LOG = LoggerFactory.getLogger(KafkaConfiguration.class);
 
   private String brokerConnect;
+  private String saslJaasConfig;
   private Boolean isSecured = false;
   private String saslMechanism;
   private String securityProtocol;
@@ -26,6 +27,7 @@ public final class KafkaConfiguration {
 
   public void applyCommon(Properties properties) {
     properties.setProperty(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, brokerConnect);
+    properties.setProperty(SaslConfigs.SASL_JAAS_CONFIG, saslJaasConfig);
     if (isSecured) {
       LOG.warn("The 'isSecured' property is deprecated; consult README.md on the preferred way to configure security");
       properties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, securityProtocol);


### PR DESCRIPTION
https://github.com/obsidiandynamics/kafdrop/pull/30 added SASL support. Currently, in order to configure SASL plain, I think the best practice for kafdrop would be to configure the appropriate login module in the sasl.jaas.config property in kafka.properties. Something like...
```
sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="USER" password="PASSWORD";
```
This unfortunately puts user/pw information in plaintext in a file when running directly from a JAR.

Due to the nature of [SpringBoot configuration](https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html), the change in this PR has the side effect of enabling configuration of the user/pw in the environment (`kafka_saslJaasConfig`) and through a command line argument (`--kafka.saslJaasConfig`) as is currently supported for brokers (`kafka_brokerConnect`/`--kafka.brokerConnect`).