### PR TITLE
Homepage performance improvement

### DIFF
--- a/src/main/java/kafdrop/controller/ConsumerController.java
+++ b/src/main/java/kafdrop/controller/ConsumerController.java
@@ -37,7 +37,7 @@ public final class ConsumerController {
 
   @RequestMapping("/{groupId:.+}")
   public String consumerDetail(@PathVariable("groupId") String groupId, Model model) throws ConsumerNotFoundException {
-    final var topicVos = kafkaMonitor.getTopics();
+    final var topicVos = kafkaMonitor.getTopicsWithOffsets();
     final var consumer = kafkaMonitor.getConsumers(topicVos)
         .stream()
         .filter(c -> c.getGroupId().equals(groupId))

--- a/src/main/java/kafdrop/controller/ConsumerController.java
+++ b/src/main/java/kafdrop/controller/ConsumerController.java
@@ -37,11 +37,8 @@ public final class ConsumerController {
 
   @RequestMapping("/{groupId:.+}")
   public String consumerDetail(@PathVariable("groupId") String groupId, Model model) throws ConsumerNotFoundException {
-    final var topicVos = kafkaMonitor.getTopicsWithOffsets();
-    final var consumer = kafkaMonitor.getConsumers(topicVos)
-        .stream()
-        .filter(c -> c.getGroupId().equals(groupId))
-        .findAny();
+    final var consumer = kafkaMonitor.getConsumersByGroup(groupId).stream().findAny();
+
     model.addAttribute("consumer", consumer.orElseThrow(() -> new ConsumerNotFoundException(groupId)));
     return "consumer-detail";
   }
@@ -53,11 +50,8 @@ public final class ConsumerController {
   })
   @GetMapping(path = "/{groupId:.+}", produces = MediaType.APPLICATION_JSON_VALUE)
   public @ResponseBody ConsumerVO getConsumer(@PathVariable("groupId") String groupId) throws ConsumerNotFoundException {
-    final var topicVos = kafkaMonitor.getTopics();
-    final var consumer = kafkaMonitor.getConsumers(topicVos)
-        .stream()
-        .filter(c -> c.getGroupId().equals(groupId))
-        .findAny();
+    final var consumer = kafkaMonitor.getConsumersByGroup(groupId).stream().findAny();
+
     return consumer.orElseThrow(() -> new ConsumerNotFoundException(groupId));
   }
 }

--- a/src/main/java/kafdrop/controller/TopicController.java
+++ b/src/main/java/kafdrop/controller/TopicController.java
@@ -60,7 +60,7 @@ public final class TopicController {
     final var topic = kafkaMonitor.getTopic(topicName)
         .orElseThrow(() -> new TopicNotFoundException(topicName));
     model.addAttribute("topic", topic);
-    model.addAttribute("consumers", kafkaMonitor.getConsumers(Collections.singleton(topic)));
+    model.addAttribute("consumers", kafkaMonitor.getConsumersByTopics(Collections.singleton(topic)));
     model.addAttribute("topicDeleteEnabled", topicDeleteEnabled);
     model.addAttribute("keyFormat", defaultKeyFormat);
     model.addAttribute("format", defaultFormat);
@@ -125,7 +125,7 @@ public final class TopicController {
   public @ResponseBody List<ConsumerVO> getConsumers(@PathVariable("name") String topicName) {
     final var topic = kafkaMonitor.getTopic(topicName)
         .orElseThrow(() -> new TopicNotFoundException(topicName));
-    return kafkaMonitor.getConsumers(Collections.singleton(topic));
+    return kafkaMonitor.getConsumersByTopics(Collections.singleton(topic));
   }
 
   /**

--- a/src/main/java/kafdrop/model/TopicVO.java
+++ b/src/main/java/kafdrop/model/TopicVO.java
@@ -18,8 +18,6 @@
 
 package kafdrop.model;
 
-import org.apache.kafka.common.PartitionInfo;
-
 import java.util.*;
 import java.util.stream.*;
 

--- a/src/main/java/kafdrop/model/TopicVO.java
+++ b/src/main/java/kafdrop/model/TopicVO.java
@@ -28,8 +28,6 @@ public final class TopicVO implements Comparable<TopicVO> {
 
   private Map<Integer, TopicPartitionVO> partitions = new TreeMap<>();
 
-  private List<PartitionInfo> partitionInfoList = new ArrayList<>();
-
   private Map<String, String> config = Collections.emptyMap();
 
   public TopicVO(String name) {
@@ -54,14 +52,6 @@ public final class TopicVO implements Comparable<TopicVO> {
 
   public void setPartitions(Map<Integer, TopicPartitionVO> partitions) {
     this.partitions = partitions;
-  }
-
-  public List<PartitionInfo> getPartitionInfoList() {
-    return this.partitionInfoList;
-  }
-
-  public void setPartitionInfoList(List<PartitionInfo> partitionInfoList) {
-    this.partitionInfoList = partitionInfoList;
   }
 
   public Optional<TopicPartitionVO> getPartition(int partitionId) {

--- a/src/main/java/kafdrop/model/TopicVO.java
+++ b/src/main/java/kafdrop/model/TopicVO.java
@@ -18,6 +18,8 @@
 
 package kafdrop.model;
 
+import org.apache.kafka.common.PartitionInfo;
+
 import java.util.*;
 import java.util.stream.*;
 
@@ -25,6 +27,8 @@ public final class TopicVO implements Comparable<TopicVO> {
   private final String name;
 
   private Map<Integer, TopicPartitionVO> partitions = new TreeMap<>();
+
+  private List<PartitionInfo> partitionInfoList = new ArrayList<>();
 
   private Map<String, String> config = Collections.emptyMap();
 
@@ -44,16 +48,20 @@ public final class TopicVO implements Comparable<TopicVO> {
     this.config = config;
   }
 
-  public Map<Integer, TopicPartitionVO> getPartitionMap() {
-    return Collections.unmodifiableMap(partitions);
-  }
-
   public Collection<TopicPartitionVO> getPartitions() {
     return Collections.unmodifiableCollection(partitions.values());
   }
 
   public void setPartitions(Map<Integer, TopicPartitionVO> partitions) {
     this.partitions = partitions;
+  }
+
+  public List<PartitionInfo> getPartitionInfoList() {
+    return this.partitionInfoList;
+  }
+
+  public void setPartitionInfoList(List<PartitionInfo> partitionInfoList) {
+    this.partitionInfoList = partitionInfoList;
   }
 
   public Optional<TopicPartitionVO> getPartition(int partitionId) {

--- a/src/main/java/kafdrop/service/KafkaHighLevelConsumer.java
+++ b/src/main/java/kafdrop/service/KafkaHighLevelConsumer.java
@@ -58,7 +58,7 @@ public final class KafkaHighLevelConsumer {
 
     kafkaConsumer.poll(Duration.ofMillis(0));
     final Set<TopicPartition> assignedPartitionList = kafkaConsumer.assignment();
-    final TopicVO topicVO = getTopicInfo(topic);
+    final TopicVO topicVO = getTopicInfo(topic, partitionInfoSet);
     final Map<Integer, TopicPartitionVO> partitionsVo = topicVO.getPartitionMap();
 
     kafkaConsumer.seekToBeginning(assignedPartitionList);
@@ -197,7 +197,11 @@ public final class KafkaHighLevelConsumer {
 
   synchronized Map<String, TopicVO> getTopicInfos(String[] topics) {
     initializeClient();
-    final var topicSet = kafkaConsumer.listTopics().keySet();
+
+    final Map<String, List<PartitionInfo>> topicsMap;
+    topicsMap = kafkaConsumer.listTopics();
+
+    final var topicSet = topicsMap.keySet();
     if (topics.length == 0) {
       topics = Arrays.copyOf(topicSet.toArray(), topicSet.size(), String[].class);
     }
@@ -205,15 +209,14 @@ public final class KafkaHighLevelConsumer {
 
     for (var topic : topics) {
       if (topicSet.contains(topic)) {
-        topicVos.put(topic, getTopicInfo(topic));
+        topicVos.put(topic, getTopicInfo(topic, topicsMap.get(topic)));
       }
     }
 
     return topicVos;
   }
 
-  private TopicVO getTopicInfo(String topic) {
-    final var partitionInfoList = kafkaConsumer.partitionsFor(topic);
+  private TopicVO getTopicInfo(String topic, List<PartitionInfo> partitionInfoList) {
     final var topicVo = new TopicVO(topic);
     final var partitions = new TreeMap<Integer, TopicPartitionVO>();
 

--- a/src/main/java/kafdrop/service/KafkaHighLevelConsumer.java
+++ b/src/main/java/kafdrop/service/KafkaHighLevelConsumer.java
@@ -48,18 +48,16 @@ public final class KafkaHighLevelConsumer {
     }
   }
 
-  synchronized void setAllPartitionSizes(Map<String, List<PartitionInfo>> topicsMap, List<TopicVO> topics) {
+  synchronized void setTopicPartitionSizes(List<TopicVO> topics) {
     initializeClient();
 
     Map<TopicVO, List<TopicPartition>> allTopics = topics.stream().map(topicVO -> {
-      List<TopicPartition> topicPartitions = topicsMap.get(topicVO.getName()).stream()
-        .map(partitionInfo -> {
-          return new TopicPartition(partitionInfo.topic(), partitionInfo.partition());
-        }).collect(Collectors.toList());
+      List<TopicPartition> topicPartitions = topicVO.getPartitions().stream().map(topicPartitionVO -> {
+        return new TopicPartition(topicVO.getName(), topicPartitionVO.getId());
+      }).collect(Collectors.toList());
 
-        return Pair.of(topicVO, topicPartitions);
-      }
-    ).collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+      return Pair.of(topicVO, topicPartitions);
+    }).collect(Collectors.toMap(Pair::getKey, Pair::getValue));
 
     List<TopicPartition> allTopicPartitions = allTopics.values().stream().flatMap(Collection::stream)
             .collect(Collectors.toList());

--- a/src/main/java/kafdrop/service/KafkaHighLevelConsumer.java
+++ b/src/main/java/kafdrop/service/KafkaHighLevelConsumer.java
@@ -3,6 +3,7 @@ package kafdrop.service;
 import kafdrop.config.*;
 import kafdrop.model.*;
 import kafdrop.util.*;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.clients.consumer.*;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.*;

--- a/src/main/java/kafdrop/service/KafkaHighLevelConsumer.java
+++ b/src/main/java/kafdrop/service/KafkaHighLevelConsumer.java
@@ -52,15 +52,16 @@ public final class KafkaHighLevelConsumer {
     initializeClient();
 
     Map<TopicVO, List<TopicPartition>> allTopics = topics.stream().map(topicVO -> {
-      List<TopicPartition> topicPartitions = topicVO.getPartitions().stream().map(topicPartitionVO -> {
-        return new TopicPartition(topicVO.getName(), topicPartitionVO.getId());
-      }).collect(Collectors.toList());
+      List<TopicPartition> topicPartitions = topicVO.getPartitions().stream().map(topicPartitionVO ->
+        new TopicPartition(topicVO.getName(), topicPartitionVO.getId())
+      ).collect(Collectors.toList());
 
       return Pair.of(topicVO, topicPartitions);
     }).collect(Collectors.toMap(Pair::getKey, Pair::getValue));
 
-    List<TopicPartition> allTopicPartitions = allTopics.values().stream().flatMap(Collection::stream)
-            .collect(Collectors.toList());
+    List<TopicPartition> allTopicPartitions = allTopics.values().stream()
+      .flatMap(Collection::stream)
+      .collect(Collectors.toList());
 
     kafkaConsumer.assign(allTopicPartitions);
     Map<TopicPartition, Long> beginningOffset = kafkaConsumer.beginningOffsets(allTopicPartitions);
@@ -209,16 +210,12 @@ public final class KafkaHighLevelConsumer {
     if (topics.length == 0) {
       topics = Arrays.copyOf(topicSet.toArray(), topicSet.size(), String[].class);
     }
-    final var topicVos = new HashMap<String, TopicVO>(topics.length, 1f);
 
-    for (var topic : topics) {
-      if (topicSet.contains(topic)) {
-        topicVos.put(topic, getTopicInfo(topic, allTopicsMap.get(topic)));
-      }
-    }
-
-    return topicVos;
-  }
+    return Arrays.stream(topics)
+      .filter(topicSet::contains)
+      .map(topic -> Pair.of(topic, getTopicInfo(topic, allTopicsMap.get(topic))))
+      .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+   }
 
   private TopicVO getTopicInfo(String topic, List<PartitionInfo> partitionInfoList) {
     final var topicVo = new TopicVO(topic);

--- a/src/main/java/kafdrop/service/KafkaHighLevelConsumer.java
+++ b/src/main/java/kafdrop/service/KafkaHighLevelConsumer.java
@@ -196,7 +196,7 @@ public final class KafkaHighLevelConsumer {
     return bytes != null ? deserializer.deserializeMessage(ByteBuffer.wrap(bytes)) : "empty";
   }
 
-  synchronized Map<String, List<PartitionInfo>> getAllTopic() {
+  synchronized Map<String, List<PartitionInfo>> getAllTopics() {
     initializeClient();
 
     return kafkaConsumer.listTopics();

--- a/src/main/java/kafdrop/service/KafkaMonitor.java
+++ b/src/main/java/kafdrop/service/KafkaMonitor.java
@@ -31,8 +31,6 @@ public interface KafkaMonitor {
 
   List<TopicVO> getTopics();
 
-  List<TopicVO> getTopicsWithOffsets();
-
   /**
    * Returns messages for a given topic.
    */
@@ -46,7 +44,9 @@ public interface KafkaMonitor {
 
   ClusterSummaryVO getClusterSummary(Collection<TopicVO> topics);
 
-  List<ConsumerVO> getConsumers(Collection<TopicVO> topicVos);
+  List<ConsumerVO> getConsumersByGroup(String groupId);
+
+  List<ConsumerVO> getConsumersByTopics(Collection<TopicVO> topicVos);
 
   /**
    * Create topic

--- a/src/main/java/kafdrop/service/KafkaMonitor.java
+++ b/src/main/java/kafdrop/service/KafkaMonitor.java
@@ -31,6 +31,8 @@ public interface KafkaMonitor {
 
   List<TopicVO> getTopics();
 
+  List<TopicVO> getTopicsWithOffsets();
+
   /**
    * Returns messages for a given topic.
    */

--- a/src/main/java/kafdrop/service/KafkaMonitorImpl.java
+++ b/src/main/java/kafdrop/service/KafkaMonitorImpl.java
@@ -114,7 +114,7 @@ public final class KafkaMonitorImpl implements KafkaMonitor {
             .sorted(Comparator.comparing(TopicVO::getName))
             .collect(Collectors.toList());
 
-    setTopicPartitionSizes(topicsMap, topicVos);
+    setTopicPartitionSizes(topicVos);
 
     return topicVos;
   }
@@ -124,7 +124,7 @@ public final class KafkaMonitorImpl implements KafkaMonitor {
     Map<String, List<PartitionInfo>> topicsMap = highLevelConsumer.getAllTopic();
 
     final var topicVo = Optional.ofNullable(getTopicMetadata(topicsMap, topic).get(topic));
-    topicVo.ifPresent(vo -> setTopicPartitionSizes(topicsMap, Collections.singletonList(vo)));
+    topicVo.ifPresent(vo -> setTopicPartitionSizes(Collections.singletonList(vo)));
     return topicVo;
   }
 
@@ -204,8 +204,8 @@ public final class KafkaMonitorImpl implements KafkaMonitor {
     return map;
   }
 
-  private void setTopicPartitionSizes(Map<String, List<PartitionInfo>> topicsMap, List<TopicVO> topics) {
-    highLevelConsumer.setAllPartitionSizes(topicsMap, topics);
+  private void setTopicPartitionSizes(List<TopicVO> topics) {
+    highLevelConsumer.setTopicPartitionSizes(topics);
   }
 
   @Override

--- a/src/main/java/kafdrop/service/KafkaMonitorImpl.java
+++ b/src/main/java/kafdrop/service/KafkaMonitorImpl.java
@@ -99,7 +99,7 @@ public final class KafkaMonitorImpl implements KafkaMonitor {
 
   @Override
   public List<TopicVO> getTopics() {
-    final var topicVos = getTopicMetadata(highLevelConsumer.getAllTopic()).values().stream()
+    final var topicVos = getTopicMetadata(highLevelConsumer.getAllTopics()).values().stream()
         .sorted(Comparator.comparing(TopicVO::getName))
         .collect(Collectors.toList());
 
@@ -108,7 +108,7 @@ public final class KafkaMonitorImpl implements KafkaMonitor {
 
   @Override
   public List<TopicVO> getTopicsWithOffsets() {
-    Map<String, List<PartitionInfo>> topicsMap = highLevelConsumer.getAllTopic();
+    Map<String, List<PartitionInfo>> topicsMap = highLevelConsumer.getAllTopics();
 
     final var topicVos = getTopicMetadata(topicsMap).values().stream()
             .sorted(Comparator.comparing(TopicVO::getName))
@@ -121,7 +121,7 @@ public final class KafkaMonitorImpl implements KafkaMonitor {
 
   @Override
   public Optional<TopicVO> getTopic(String topic) {
-    Map<String, List<PartitionInfo>> topicsMap = highLevelConsumer.getAllTopic();
+    Map<String, List<PartitionInfo>> topicsMap = highLevelConsumer.getAllTopics();
 
     final var topicVo = Optional.ofNullable(getTopicMetadata(topicsMap, topic).get(topic));
     topicVo.ifPresent(vo -> setTopicPartitionSizes(Collections.singletonList(vo)));

--- a/src/main/java/kafdrop/service/KafkaMonitorImpl.java
+++ b/src/main/java/kafdrop/service/KafkaMonitorImpl.java
@@ -102,16 +102,16 @@ public final class KafkaMonitorImpl implements KafkaMonitor {
     final var topicVos = getTopicMetadata().values().stream()
         .sorted(Comparator.comparing(TopicVO::getName))
         .collect(Collectors.toList());
-    for (var topicVo : topicVos) {
-      topicVo.setPartitions(getTopicPartitionSizes(topicVo));
-    }
+
+    setTopicPartitionSizes(topicVos);
+
     return topicVos;
   }
 
   @Override
   public Optional<TopicVO> getTopic(String topic) {
     final var topicVo = Optional.ofNullable(getTopicMetadata(topic).get(topic));
-    topicVo.ifPresent(vo -> vo.setPartitions(getTopicPartitionSizes(vo)));
+    topicVo.ifPresent(vo -> setTopicPartitionSizes(Collections.singletonList(vo)));
     return topicVo;
   }
 
@@ -191,8 +191,8 @@ public final class KafkaMonitorImpl implements KafkaMonitor {
     return map;
   }
 
-  private Map<Integer, TopicPartitionVO> getTopicPartitionSizes(TopicVO topic) {
-    return highLevelConsumer.getPartitionSize(topic.getName());
+  private void setTopicPartitionSizes(List<TopicVO> topics) {
+    highLevelConsumer.setAllPartitionSizes(topics);
   }
 
   @Override

--- a/src/main/java/kafdrop/service/KafkaMonitorImpl.java
+++ b/src/main/java/kafdrop/service/KafkaMonitorImpl.java
@@ -103,6 +103,13 @@ public final class KafkaMonitorImpl implements KafkaMonitor {
         .sorted(Comparator.comparing(TopicVO::getName))
         .collect(Collectors.toList());
 
+    return topicVos;
+  }
+
+  @Override
+  public List<TopicVO> getTopicsWithOffsets() {
+    final var topicVos = getTopics();
+
     setTopicPartitionSizes(topicVos);
 
     return topicVos;


### PR DESCRIPTION
This refactoring makes it possible to load in my case 1600 topic with 11000 topic partition in 30 seconds (tested with a kafka stack that is other side of the world which means a higher ttl) and consists of several changes. Without these changes it was impossible to load the homepage. 

Main point is that this can be achieved by not going to kafka where its not needed, or combine several calls into one.

### Total kafka calls removed:
- (n * topic kafkaConsumer.beginningOffsets) - 1
- (n * topic kafkaConsumer.endOffsets) - 1
- n * topic kafkaConsumer.partitionsFor

### TopicInfo
When retrieving the topicInfo it was first doing the listTopics and subsequenty looping over them to retrieve the partitions. The partition data is however already part of the listTopics data. Instead of going to kafka again for the data for each topic I'm just getting it from the listTopics data.

Old version:
- 1 listTopics call
- n * topic kafkaConsumer.partitionsFor call

New version
- 1 listTopics call

### PartitionSizes
When getting the partition sizes the code now get the partition start en end offset by doing 2 call per topic. For the kafka consumer call you only give it the partitions of the topic, not the topic. Instead of giving it the partition of 1 topic why not all partition at once.

Old version:
- n * topic kafkaConsumer.beginningOffsets
- n * topic kafkaConsumer.endOffsets

New version
- 1 * kafkaConsumer.beginningOffsets
- 1 * kafkaConsumer.endOffsets

### Homepage improvement
On the homepage and other pages we actually don't need the partition sizes but its being retrieved regardless. So I splitted the getTopics in 2 methods, one with and one without the partition sizes

Old version:
- n * topic kafkaConsumer.beginningOffsets

New version
- omitted

Fix #246
Fix #233