### PR TITLE
add keyFormat and format query params to the view message link for topics

### DIFF
--- a/src/main/resources/templates/topic-detail.ftlh
+++ b/src/main/resources/templates/topic-detail.ftlh
@@ -124,7 +124,7 @@
                 <tbody>
                 <#list topic.partitions as p>
                     <tr>
-                        <td><a href="<@spring.url '/topic/${topic.name}/messages?partition=${p.id}&offset=${p.firstOffset}&count=100'/>">${p.id}</a></td>
+                        <td><a href="<@spring.url '/topic/${topic.name}/messages?partition=${p.id}&offset=${p.firstOffset}&count=100&keyFormat${keyFormat}=&format=${format}'/>">${p.id}</a></td>
                         <td>${p.firstOffset}</td>
                         <td>${p.size}</td>
                         <td>${p.size - p.firstOffset}</td>


### PR DESCRIPTION
I noticed that the view message for topic did not have the keyFormat and format query params specified which causes the message to be de-serialized in the "DEFAULT" format instead of the message.format specified in the config.

Fix #239 