### PR TITLE
Disable TRACE/TRACK method in Undertow for security reasons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <additionalOptions>-Xdoclint:none</additionalOptions>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <protobuf.version>3.11.1</protobuf.version>
-        <testcontainers.version>1.14.3</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
     </properties>
 
     <scm>
@@ -204,6 +204,20 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter -->
+        <!-- Provides everything you need to write JUnit 5 Jupiter tests. -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.7.1</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin -->
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.0.0-M5</version>
+        </dependency>
 
         <!-- Testcontainers -->
         <dependency>
@@ -322,6 +336,12 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <!-- JUnit 5 requires Surefire version 2.22.0 or higher -->
+                <version>2.22.0</version>
             </plugin>
         </plugins>
         <resources>

--- a/src/main/java/kafdrop/Kafdrop.java
+++ b/src/main/java/kafdrop/Kafdrop.java
@@ -20,6 +20,8 @@ package kafdrop;
 
 import com.google.common.base.*;
 import io.undertow.server.*;
+import io.undertow.server.handlers.DisallowedMethodsHandler;
+import io.undertow.util.HttpString;
 import io.undertow.websockets.jsr.*;
 import kafdrop.config.ini.*;
 import org.slf4j.*;
@@ -64,6 +66,17 @@ public class Kafdrop {
         var inf = new WebSocketDeploymentInfo();
         inf.setBuffers(new DefaultByteBufferPool(false, 64));
         deploymentInfo.addServletContextAttribute(WebSocketDeploymentInfo.ATTRIBUTE_NAME, inf);
+        // see https://stackoverflow.com/a/54129696
+        deploymentInfo.addInitialHandlerChainWrapper(new HandlerWrapper() {
+          @Override
+          public HttpHandler wrap(HttpHandler handler) {
+            HttpString[] disallowedHttpMethods = {
+              HttpString.tryFromString("TRACE"),
+              HttpString.tryFromString("TRACK")
+            };
+            return new DisallowedMethodsHandler(handler, disallowedHttpMethods);
+          }
+        });
       };
       factory.addDeploymentInfoCustomizers(customizer);
     };

--- a/src/main/java/kafdrop/controller/ClusterController.java
+++ b/src/main/java/kafdrop/controller/ClusterController.java
@@ -121,5 +121,17 @@ public final class ClusterController {
     ClusterSummaryVO summary;
     List<BrokerVO> brokers;
     List<TopicVO> topics;
+
+    public ClusterSummaryVO getSummary() {
+      return summary;
+    }
+
+    public List<BrokerVO> getBrokers() {
+      return brokers;
+    }
+
+    public List<TopicVO> getTopics() {
+      return topics;
+    }
   }
 }

--- a/src/main/resources/templates/acl-overview.ftlh
+++ b/src/main/resources/templates/acl-overview.ftlh
@@ -38,12 +38,12 @@
     <table class="table table-bordered">
         <thead>
         <tr>
-            <th><i class="fa fa-tag"></i>&nbsp;&nbsp;Pattern Name</th>
-            <th><i class="fa fa-user"></i>&nbsp;&nbsp;Principal</th>
+            <th style="hyphens:none;white-space:nowrap"><i class="fa fa-tag"></i>&nbsp;&nbsp;Pattern Name</th>
+            <th style="hyphens:none;white-space:nowrap"><i class="fa fa-user"></i>&nbsp;&nbsp;Principal</th>
             <th><i class="fa fa-user"></i>&nbsp;&nbsp;Resource Type</th>
             <th><i class="fa fa-tag"></i>&nbsp;&nbsp;Pattern Type</th>
-            <th><i class="fa fa-tag"></i>&nbsp;&nbsp;Operation</th>
-            <th><i class="fa fa-server"></i>&nbsp;&nbsp;Host</th>
+            <th style="hyphens:none;white-space:nowrap"><i class="fa fa-tag"></i>&nbsp;&nbsp;Operation</th>
+            <th style="hyphens:none;white-space:nowrap"><i class="fa fa-server"></i>&nbsp;&nbsp;Host</th>
             <th><i class="fa fa-tag"></i>&nbsp;&nbsp;Permission Type</th>
         </tr>
         </thead>
@@ -51,7 +51,7 @@
         <#list acls as a>
             <tr class="dataRow">
                 <td>${a.name}</td>
-                <td>${a.principal}</td>
+                <td style="hyphens:none;white-space:nowrap">${a.principal}</td>
                 <td>${a.resourceType}</td>
                 <td>${a.patternType}</td>
                 <td>${a.operation}</td>

--- a/src/main/resources/templates/cluster-overview.ftlh
+++ b/src/main/resources/templates/cluster-overview.ftlh
@@ -30,7 +30,7 @@
             <tbody>
             <tr>
                 <td><i class="fa fa-server"></i>&nbsp;&nbsp;Bootstrap servers</td>
-                <td>${bootstrapServers}</td>
+                <td style="max-width:800px;word-wrap:break-word">${bootstrapServers}</td>
             </tr>
             <tr>
                 <td><i class="fa fa-database"></i>&nbsp;&nbsp;Total topics</td>

--- a/src/test/java/kafdrop/KafdropTest.java
+++ b/src/test/java/kafdrop/KafdropTest.java
@@ -1,8 +1,52 @@
 package kafdrop;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpMethod.TRACE;
+import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED;
+import static org.springframework.http.HttpStatus.OK;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class KafdropTest extends AbstractIntegrationTest {
-    @Test
-    public void contextTest(){}
+
+  @LocalServerPort
+  private int port;
+
+  @Autowired
+  private Kafdrop kafdrop;
+
+  @Autowired
+  private TestRestTemplate restTemplate;
+
+  @Test
+  public void contextLoads() throws Exception {
+    assertThat(kafdrop).isNotNull();
+  }
+
+  @Test
+  public void getReturnsExpectedGutHubStarText() throws Exception {
+    ResponseEntity<String> responseEntity = restTemplate
+            .getForEntity("http://localhost:" + port + "/", String.class);
+    assertEquals(OK, responseEntity.getStatusCode());
+    assertThat(responseEntity.getBody().contains("Star Kafdrop on GitHub"));
+  }
+
+  @Test
+  public void traceMethodExpectedDisallowedReturnCode() throws Exception {
+    ResponseEntity<String> response = restTemplate
+            .exchange("http://localhost:" + port + "/", TRACE, null, String.class);
+      assertEquals(METHOD_NOT_ALLOWED, response.getStatusCode());
+  }
 }

--- a/src/test/java/kafdrop/model/ConsumerPartitionVOTest.java
+++ b/src/test/java/kafdrop/model/ConsumerPartitionVOTest.java
@@ -18,17 +18,22 @@
 
 package kafdrop.model;
 
-import org.junit.*;
+import static org.assertj.core.api.Assertions.*;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+@ExtendWith(SpringExtension.class)
+@SpringBootTest()
 public final class ConsumerPartitionVOTest {
   private void doLagTest(long first, long last, long offset, long expectedLag) {
     final var partition = new ConsumerPartitionVO("test", "test", 0);
     partition.setFirstOffset(first);
     partition.setSize(last);
     partition.setOffset(offset);
-    assertEquals("Unexpected lag", expectedLag, partition.getLag());
+    assertThat(expectedLag).isEqualTo(partition.getLag());
   }
 
   @Test


### PR DESCRIPTION
Disable TRACE/TRACK method in Undertow for security reasons.  Resolves #180, resolves #194.  Working unit tests required updates to testcontainers and junit-jupiter.  Small UI changes to force text wrap for long bootstrap servers list and to prevent text wrap on some ACL fields containing values with hyphens.