### PR TITLE
Use configurable $SERVER_PORT for management endpoints

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,7 @@ management:
       base-path: /actuator
       exposure.include: "*"
   server:
-    port: 9000
+    port: ${SERVER_PORT:9000}
 
 kafdrop.monitor:
   clientId: Kafdrop


### PR DESCRIPTION
If using the `$SERVER_PORT` environment variable for configuring the server port, management endpoints still use always the port **9000**.

I think it would be nice to also use the `$SERVER_PORT` value there.