### PR TITLE
Add Openshift Route

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "3.x"
 description: A Helm chart for Kafdrop
 name: kafdrop
-version: 0.1.0
+version: 0.1.1

--- a/chart/templates/route.yaml
+++ b/chart/templates/route.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.route.enabled -}}
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.selectorLabels" . | nindent 4 }}
+spec:
+  to:
+    kind: Service
+    name: {{ include "chart.fullname" . }}
+    weight: 100
+  port:
+    targetPort: http
+  {{- if .Values.route.tls }}
+  tls:
+    {{- if .Values.route.tls.termination }}
+    termination: {{ .Values.route.tls.termination }}
+    {{- end}}
+    {{- if .Values.route.tls.insecureEdgeTerminationPolicy }}
+    insecureEdgeTerminationPolicy: {{ .Values.route.tls.insecureEdgeTerminationPolicy }}
+    {{- end}}
+  {{- end }}
+  wildcardPolicy: None
+{{- end }}

--- a/chart/templates/route.yaml
+++ b/chart/templates/route.yaml
@@ -4,7 +4,10 @@ apiVersion: route.openshift.io/v1
 metadata:
   name: {{ include "chart.fullname" . }}
   labels:
-    {{- include "chart.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "chart.name" . }}
+    helm.sh/chart: {{ include "chart.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   to:
     kind: Service

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -44,6 +44,12 @@ ingress:
   hosts: []
   tls: []
 
+route:
+  enabled: false
+  # tls:
+  #   termination: edge
+  #   insecureEdgeTerminationPolicy: Allow
+
 resources:
   # limits:
   #  cpu: 100m


### PR DESCRIPTION
OpenShift routes are an alternative to an ingress object.

This update adds an optional route object that can be enabled or disabled in a similar way to an ingress object.