### PR TITLE
Fixed can't evaluate field hosts in ingress.yaml

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "chart.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- $hosts := .Values.ingress.hosts -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -19,14 +20,14 @@ spec:
   tls:
   {{- range .Values.ingress.tls }}
     - hosts:
-      {{- range .hosts }}
+      {{- range $hosts }}
         - {{ . | quote }}
       {{- end }}
       secretName: {{ .secretName }}
   {{- end }}
 {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
+  {{- range $hosts }}
     - host: {{ . | quote }}
       http:
         paths:


### PR DESCRIPTION
An error occurred when enabling ingress:

> `Error: UPGRADE FAILED: template: ingress.yaml:22:16: executing "hansken/charts/kafdrop/templates/ingress.yaml" at <.hosts>: can't evaluate field hosts in type interface {}`

