### PR TITLE
Update spring boot to 2.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.1</version>
+        <version>2.6.2</version>
     </parent>
     <groupId>com.obsidiandynamics.kafdrop</groupId>
     <artifactId>kafdrop</artifactId>
@@ -23,7 +23,6 @@
         <protobuf.version>3.19.1</protobuf.version>
         <testcontainers.version>1.16.2</testcontainers.version>
         <kafka-libs.version>6.1.4</kafka-libs.version>
-        <log4j2.version>2.17.0</log4j2.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
Update `spring-boot-starter-parent` to get new log4j version 2.17.0.
Spring boot depends directly on correct log4j version so we don't need to override it anymore.

cc @mcs @ekoutanov 