### PR TITLE
remove redundant "org.junit.vintage" exclusion.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,12 +186,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>junit-vintage-engine</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Testcontainers -->


### PR DESCRIPTION
Since Spring Boot 2.4, JUnit 5’s vintage engine has been removed from spring-boot-starter-test.
Details: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.4-Release-Notes#junit-5s-vintage-engine-removed-from-spring-boot-starter-test