### PR TITLE
remove unsafe cast and redundant @ExtendWith

### DIFF
--- a/src/test/java/kafdrop/AbstractIntegrationTest.java
+++ b/src/test/java/kafdrop/AbstractIntegrationTest.java
@@ -1,12 +1,10 @@
 package kafdrop;
 
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerImageName;
@@ -14,24 +12,22 @@ import org.testcontainers.utility.DockerImageName;
 import java.util.List;
 import java.util.Map;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ContextConfiguration(initializers = AbstractIntegrationTest.Initializer.class)
 abstract class AbstractIntegrationTest {
     static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
         static KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka").withTag("5.4.3"));
 
-        public static Map<String, String> getProperties() {
+        public static Map<String, Object> getProperties() {
             Startables.deepStart(List.of(kafka)).join();
             return Map.of("kafka.brokerConnect", kafka.getBootstrapServers());
         }
 
         @Override
-        @SuppressWarnings("unchecked, rawtypes")
         public void initialize(ConfigurableApplicationContext context) {
             var env = context.getEnvironment();
             env.getPropertySources().addFirst(new MapPropertySource(
-                    "testcontainers", (Map) getProperties()
+                    "testcontainers", getProperties()
             ));
         }
     }


### PR DESCRIPTION
Constructor of `MapPropertySource` receives ` Map<String,Object> source` so we may avoid unsafe casting: 

Javadoc: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/env/MapPropertySource.html#MapPropertySource-java.lang.String-java.util.Map-

Also:  `@ExtendWith(SpringExtension.class)` is already included in `@SpringBootTest`:

Javadoc: https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/test/context/SpringBootTest.html