### PR TITLE
fix: include error message in error page

### DIFF
--- a/src/main/java/kafdrop/controller/BasicErrorController.java
+++ b/src/main/java/kafdrop/controller/BasicErrorController.java
@@ -22,8 +22,15 @@ public final class BasicErrorController extends AbstractErrorController {
 
   @RequestMapping("/error")
   public ModelAndView handleError(HttpServletRequest request) {
-    final var error = getErrorAttributes(request, ErrorAttributeOptions.of(ErrorAttributeOptions.Include.STACK_TRACE));
+    final var errorAttributeOptions = ErrorAttributeOptions.of(
+      ErrorAttributeOptions.Include.STACK_TRACE,
+      ErrorAttributeOptions.Include.MESSAGE);
+
+    final var error = getErrorAttributes(request, errorAttributeOptions);
     LOG.info("errorAtts: {}", error);
+    
+    error.putIfAbsent("message", "");
+
     final var model = Map.of("error", error);
     return new ModelAndView("error", model);
   }


### PR DESCRIPTION
Close #332

It seems that the bug was caused by the fact that the error model doesn't contain the `message` property anymore.
So I have explicitly included it using `ErrorAttributeOptions` and I have also set it to a default in case it is still missing.

Still not sure why this is happing now, I suspect it is something related to the new spring boot version.