### PR TITLE
Override log4j to 2.17.1 to address CVE-2021-44832

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <protobuf.version>3.19.1</protobuf.version>
         <testcontainers.version>1.16.2</testcontainers.version>
         <kafka-libs.version>6.1.4</kafka-libs.version>
+        <log4j2.version>2.17.1</log4j2.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
Log4j v2.17.0 is vulnerable to CVE-2021-44832 and as such it`s being flagged in conservative organisations.
Upgrading to 2.17.1 to resolve and be able to continue using Kafdrop.