### PR TITLE
skip topic when a TopicAuthorizationException occurs

### DIFF
--- a/src/main/java/kafdrop/service/KafkaHighLevelAdminClient.java
+++ b/src/main/java/kafdrop/service/KafkaHighLevelAdminClient.java
@@ -110,6 +110,7 @@ public final class KafkaHighLevelAdminClient {
         return Map.of();
       } else if (e.getCause() instanceof TopicAuthorizationException) {
         printAcls();
+        return Map.of();
       }
       throw new KafkaAdminClientException(e);
     }


### PR DESCRIPTION
Fix #208

When a TopicAuthorizationException occurs we just skip the Topics and continue loading the page