### PR TITLE
Update spring and use Log4j version managed by it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.2</version>
+        <version>2.6.3</version>
     </parent>
     <groupId>com.obsidiandynamics.kafdrop</groupId>
     <artifactId>kafdrop</artifactId>
@@ -23,7 +23,6 @@
         <protobuf.version>3.19.1</protobuf.version>
         <testcontainers.version>1.16.2</testcontainers.version>
         <kafka-libs.version>6.1.4</kafka-libs.version>
-        <log4j2.version>2.17.1</log4j2.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
Explicit specification of Log4j version introduced in https://github.com/obsidiandynamics/kafdrop/pull/339 is no longer needed to mitigate [CVE-2021-44832](https://github.com/advisories/GHSA-8489-44mv-ggj8) because [spring boot v2.6.3](https://github.com/spring-projects/spring-boot/releases/tag/v2.6.3) has been released and includes Log4j2 2.17.1. Thus this dependency can be managed as it used to be in the same way as proposed in https://github.com/obsidiandynamics/kafdrop/commit/d41c245ff44460668058988b4e4e3f3dce170676.