### PR TITLE
release 3.30.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.obsidiandynamics.kafdrop</groupId>
     <artifactId>kafdrop</artifactId>
-    <version>3.29.0-SNAPSHOT</version>
+    <version>3.30.0</version>
 
     <description>For when you have a Kafka cluster to monitor</description>
 


### PR DESCRIPTION
Could the current version released to docker?

Not sure what the release step are, but noticed in the github workflow that at least this version should be updated. Probably after this merge it should be set to the next SNAPSHOT version again