### PR TITLE
Helm chart: Add "extraEnvVars"

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -30,8 +30,10 @@ spec:
           env:
           - name: KAFKA_BROKERCONNECT
             value: "{{ .Values.kafka.brokerConnect }}"
+          {{- if .Values.kafka.properties }}
           - name: KAFKA_PROPERTIES
             value: "{{ .Values.kafka.properties }}"
+          {{- end }}
           - name: KAFKA_TRUSTSTORE
             value: "{{ .Values.kafka.truststore }}"
           - name: KAFKA_KEYSTORE

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -52,6 +52,9 @@ spec:
             value: "{{ .Values.kafka.keystoreFile }}"
           - name: SERVER_PORT
             value: "{{ .Values.server.port }}"
+          {{- if .Values.extraEnvVars }}
+          {{- .Values.extraEnvVars | toYaml | nindent 10 }}
+          {{- end }}
           - name: CMD_ARGS
 {{- if .Values.mountProtoDesc.enabled }}
             value: "--message.format=PROTOBUF --protobufdesc.directory=/protodesc/ {{ .Values.cmdArgs }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,5 +1,10 @@
 replicaCount: 1
 
+## extraEnvVars:
+##   - name: FOO
+##     value: "bar"
+extraEnvVars: []
+
 image:
   repository: obsidiandynamics/kafdrop
   tag: latest


### PR DESCRIPTION
This change allows users to add additional env vars to the helm release.

We needed this in order to be able to populate our kafka properties in a secure way. For instance with this we use:

```
extraEnvVars:
  - name: "KAFKA_PROPERTIES"
    valueFrom:
      secretKeyRef:
        name: kafdrop-kafka-properties
        key: properties
```

This change should be backwards compatible.