### PR TITLE
security: Update to Spring Boot 2.6.6 to address 2 CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>2.6.6</version>
     </parent>
     <groupId>com.obsidiandynamics.kafdrop</groupId>
     <artifactId>kafdrop</artifactId>


### PR DESCRIPTION
Addresses 2 CVEs

[CVE-2020-36518](https://nvd.nist.gov/vuln/detail/CVE-2020-36518)
Spring Boot 2.6.6 pulls in jackson-databind-2.13.2.2 which contains the remediation for the CVE
```
> jar -tvf kafdrop-3.30.0-SNAPSHOT.jar | grep jackson-databind
1535087 Tue Mar 29 02:00:16 MDT 2022 BOOT-INF/lib/jackson-databind-2.13.2.2.jar
```

Closes #367
Closes #365


[CVE-2022-22965](https://nvd.nist.gov/vuln/detail/CVE-2022-22965)
https://snyk.io/blog/spring4shell-zero-day-rce-spring-framework-explained/
Spring Boot 2.6.6 pulls in springframework 5.3.18 which contains the remediation for the CVE
Closes https://github.com/obsidiandynamics/kafdrop/issues/365
```
> jar -tvf target/kafdrop-3.30.0-SNAPSHOT.jar| grep spring-bean
698595 Thu Mar 31 08:50:18 MDT 2022 BOOT-INF/lib/spring-beans-5.3.18.jar
```