### PR TITLE
[issue-373] Changed list consumer groups fetching way from all to valid

### DIFF
--- a/src/main/java/kafdrop/service/KafkaHighLevelAdminClient.java
+++ b/src/main/java/kafdrop/service/KafkaHighLevelAdminClient.java
@@ -72,7 +72,7 @@ public final class KafkaHighLevelAdminClient {
   Set<String> listConsumerGroups() {
     final Collection<ConsumerGroupListing> groupListing;
     try {
-      groupListing = adminClient.listConsumerGroups().all().get();
+      groupListing = adminClient.listConsumerGroups().valid().get();
     } catch (InterruptedException | ExecutionException e) {
       throw new KafkaAdminClientException(e);
     }


### PR DESCRIPTION
## Related Issues
- https://github.com/obsidiandynamics/kafdrop/issues/373

<br>

## Contents
- As I wrote in issue above, everytime I access to topic page, `ClusterAuthorizationException` occurred
- So, I changed list consumer groups fetching policy from `all()` to `valid()` to ensure see topic page without consumer at least

<br>

## PR Points
- I tested it with my cluster that occurred this error and It's working well
    - Before change (used `all()`)
        <img src="https://user-images.githubusercontent.com/20942871/163574905-63ce2eb8-7ad4-4092-a36b-d2a812126cf9.png" width="70%" alt="topic page error"/>
    - After change (used `valid()`)
        <img src="https://user-images.githubusercontent.com/20942871/163576998-10c1da48-0dfa-4b25-84fc-6087d50d4d96.png" width="70%" alt="fixed topic page"/>
- I think it is not a critical change but If you have any unclear things or any questions, just tell me anytime 🙏

<br>