### PR TITLE
Add configurable support for Kubernetes 1.22 Ingress v1beta1 obsoletion

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -30,3 +30,23 @@ Create chart name and version as used by the chart label.
 {{- define "chart.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "capabilities.kubeVersion" }}
+{{- if .Values.global.kubeVersion -}}
+{{- .Values.global.kubeVersion -}}
+{{- else -}}
+{{- .Capabilities.KubeVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ingress.apiVersion" }}
+{{- if .Values.ingress.apiVersion -}}
+{{- .Values.ingress.apiVersion -}}
+{{- else if semverCompare "<1.14-0" (include "capabilities.kubeVersion" .) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" (include "capabilities.kubeVersion" .) -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end }}
+{{- end }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "chart.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ include "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -30,9 +30,19 @@ spec:
     - host: {{ . | quote }}
       http:
         paths:
+          {{- if eq "networking.k8s.io/v1" (include "ingress.apiVersion" $) }}
+          - path: {{ $ingressPath }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
+          {{- else }}
           - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: http
+          {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -45,6 +45,7 @@ ingress:
   apiVersion: ~
   annotations: {}
   path: /
+  pathType: ~
   hosts: []
   tls: []
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -26,6 +26,9 @@ fullnameOverride: ""
 
 cmdArgs: ""
 
+global:
+  kubeVersion: ~
+
 server:
   port: 9000
   servlet:
@@ -39,6 +42,7 @@ service:
 
 ingress:
   enabled: false
+  apiVersion: ~
   annotations: {}
   path: /
   hosts: []


### PR DESCRIPTION
Note `helm template` by default will have `.Capabilities.KubeVersion` based on a hard-coded test value without `--kube-version` set. helm install/upgrade will detect from the cluster.

Alternatively `global.kubeVersion` or `ingress.apiVersion` be set