### PR TITLE
Add configurable pathType and ingressClassName to Ingress

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -32,7 +32,7 @@ spec:
                 port:
                   name: http
           {{- else }}
-            {{- with (pick $ingress "path" "pathType") }}
+          - {{- with (pick $ingress "path" "pathType") }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
             backend:

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "chart.fullname" . -}}
-{{- $ingressPath := .Values.ingress.path -}}
+{{- $ingress := .Values.ingress -}}
 apiVersion: {{ include "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -10,36 +10,31 @@ metadata:
     helm.sh/chart: {{ include "chart.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- with .Values.ingress.annotations }}
+{{- with $ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
+  {{- with (pick $ingress "ingressClassName" "tls") }}
+  {{- . | toYaml | nindent 2 }}
   {{- end }}
-{{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
     - host: {{ . | quote }}
       http:
         paths:
           {{- if eq "networking.k8s.io/v1" (include "ingress.apiVersion" $) }}
-          - path: {{ $ingressPath }}
-            pathType: Prefix
+          - path: {{ $ingress.path }}
+            pathType: {{ $ingress.pathType | default "ImplementationSpecific" }}
             backend:
               service:
                 name: {{ $fullName }}
                 port:
                   name: http
           {{- else }}
-          - path: {{ $ingressPath }}
+            {{- with (pick $ingress "path" "pathType") }}
+            {{- . | toYaml | nindent 12 }}
+            {{- end }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: http

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -42,8 +42,9 @@ service:
 
 ingress:
   enabled: false
-  apiVersion: ~
   annotations: {}
+  apiVersion: ~
+  ingressClassName: ~
   path: /
   pathType: ~
   hosts: []

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -44,9 +44,9 @@ ingress:
   enabled: false
   annotations: {}
   apiVersion: ~
-  ingressClassName: ~
+  #ingressClassName: ~
   path: /
-  pathType: ~
+  #pathType: ~
   hosts: []
   tls: []
 


### PR DESCRIPTION
The previous PR I missed completing the pathType changes I was meaning to add support for.

Now we have ingressClassName as well, which is much more relevant when using v1 Ingresses (e.g. ingress-nginx requires use of IngressClass for them)

pathType was optional in v1beta, and not available before 1.18, but is mandatory in v1, however changing to the previous default pathType that would be used for backwards-compatibility