### PR TITLE
Disable HTTP TRACE and TRACK methods

### DIFF
--- a/src/main/java/kafdrop/Kafdrop.java
+++ b/src/main/java/kafdrop/Kafdrop.java
@@ -20,6 +20,8 @@ package kafdrop;
 
 import com.google.common.base.*;
 import io.undertow.server.*;
+import io.undertow.server.handlers.DisallowedMethodsHandler;
+import io.undertow.util.HttpString;
 import io.undertow.websockets.jsr.*;
 import kafdrop.config.ini.*;
 import org.slf4j.*;
@@ -64,6 +66,17 @@ public class Kafdrop {
         var inf = new WebSocketDeploymentInfo();
         inf.setBuffers(new DefaultByteBufferPool(false, 64));
         deploymentInfo.addServletContextAttribute(WebSocketDeploymentInfo.ATTRIBUTE_NAME, inf);
+        // see https://stackoverflow.com/a/54129696
+        deploymentInfo.addInitialHandlerChainWrapper(new HandlerWrapper() {
+          @Override
+          public HttpHandler wrap(HttpHandler handler) {
+            HttpString[] disallowedHttpMethods = {
+              HttpString.tryFromString("TRACE"),
+              HttpString.tryFromString("TRACK")
+            };
+            return new DisallowedMethodsHandler(handler, disallowedHttpMethods);
+          }
+        });
       };
       factory.addDeploymentInfoCustomizers(customizer);
     };

--- a/src/main/java/kafdrop/controller/ClusterController.java
+++ b/src/main/java/kafdrop/controller/ClusterController.java
@@ -121,5 +121,16 @@ public final class ClusterController {
     ClusterSummaryVO summary;
     List<BrokerVO> brokers;
     List<TopicVO> topics;
+    public ClusterSummaryVO getSummary() {
+      return summary;
+    }
+
+    public List<BrokerVO> getBrokers() {
+      return brokers;
+    }
+
+    public List<TopicVO> getTopics() {
+      return topics;
+    }
   }
 }

--- a/src/test/java/kafdrop/KafdropTest.java
+++ b/src/test/java/kafdrop/KafdropTest.java
@@ -1,0 +1,52 @@
+package kafdrop;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpMethod.TRACE;
+import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED;
+import static org.springframework.http.HttpStatus.OK;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class KafdropTest extends AbstractIntegrationTest {
+
+  @LocalServerPort
+  private int port;
+
+  @Autowired
+  private Kafdrop kafdrop;
+
+  @Autowired
+  private TestRestTemplate restTemplate;
+
+  @Test
+  public void contextLoads() throws Exception {
+    assertThat(kafdrop).isNotNull();
+  }
+
+  @Test
+  public void getReturnsExpectedGutHubStarText() throws Exception {
+    ResponseEntity<String> responseEntity = restTemplate
+            .getForEntity("http://localhost:" + port + "/", String.class);
+    assertEquals(OK, responseEntity.getStatusCode());
+    assertThat(responseEntity.getBody().contains("Star Kafdrop on GitHub"));
+  }
+
+  @Test
+  public void traceMethodExpectedDisallowedReturnCode() throws Exception {
+    ResponseEntity<String> response = restTemplate
+            .exchange("http://localhost:" + port + "/", TRACE, null, String.class);
+      assertEquals(METHOD_NOT_ALLOWED, response.getStatusCode());
+  }
+}


### PR DESCRIPTION
 Corporate Security Scanners find both the HTTP TRACE and TRACK methods to be exploitable so this modifies the default behavior of Undertow to disallow those methods.  I've included a test to ensure that rejection occurs.