### PR TITLE
Uses fabric8io docker maven plugin

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -26,7 +26,7 @@ jobs:
         echo "app_ver=$(mvn -B help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
     -
       name: Build with Maven
-      run: mvn -B clean integration-test package assembly:single docker:build
+      run: mvn -B clean integration-test package docker:build
 
 # github_release:
     -

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <protobuf.version>3.19.1</protobuf.version>
         <testcontainers.version>1.16.2</testcontainers.version>
         <kafka-libs.version>6.1.4</kafka-libs.version>
+        <docker.base.image>eclipse-temurin:11</docker.base.image>
     </properties>
 
     <scm>
@@ -221,14 +222,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <configuration>
-                    <descriptors>
-                        <descriptor>src/main/assembly/bin.xml</descriptor>
-                    </descriptors>
-                </configuration>
-            </plugin>
-            <plugin>
                 <!-- Build an executable JAR -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -243,24 +236,29 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
+                <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>1.2.0</version>
+                <version>0.40.1</version>
                 <configuration>
-                    <imageName>obsidiandynamics/kafdrop</imageName>
-                    <forceTags>true</forceTags>
-                    <dockerDirectory>${project.build.directory}/docker-ready</dockerDirectory>
-                    <imageTags>
-                        <imageTag>${project.version}</imageTag>
-                        <imageTag>latest</imageTag>
-                    </imageTags>
-                    <resources>
-                        <resource>
-                            <targetPath>/</targetPath>
-                            <directory>${project.build.directory}</directory>
-                            <include>${project.build.finalName}-bin.tar.gz</include>
-                        </resource>
-                    </resources>
+                    <verbose>true</verbose>
+                    <sourceDirectory>src/main/assembly</sourceDirectory>
+                    <images>
+                        <image>
+                            <name>obsidiandynamics/kafdrop</name>
+                            <build>
+                                <tags>
+                                    <tag>${project.version}</tag>
+                                    <tag>latest</tag>
+                                </tags>
+                                <contextDir>${project.build.directory}/docker-ready</contextDir>
+                                <assembly>
+                                    <name>${project.build.finalName}</name>
+                                    <mode>tar</mode>
+                                    <descriptor>bin.xml</descriptor>
+                                </assembly>
+                            </build>
+                        </image>
+                    </images>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,7 +1,7 @@
-FROM eclipse-temurin:11
+FROM ${docker.base.image}
 
 ADD kafdrop.sh /
-ADD kafdrop*tar.gz /
+ADD ${project.build.finalName} /${project.build.finalName}
 
 RUN chmod +x /kafdrop.sh
 


### PR DESCRIPTION
The purpose of this MR is to move to fabric8io docker maven plugin as spotify docker maven plugin is no longer maintained and doesn't provide arm64 compatibility.

With the given setup, one can change the base image using property -Ddocker.base.image while building.

`eclipse-temurin` doesn't have arm64 compatible manifest as of now but has arm images under `arm64v8/eclipse-temurin`.

Also github workflows have runners based on amd64 processors while circleci has runners available for both arm64 and amd64 machines.

So in all it would be a tough setup to provide arm compatible images but this MR would still help someone who is building locally.

On the other hand in my fork I can work on to provide an arm64 compatible counterpart of kafdrop in the interim a solution is being discovered.