### PR TITLE
feat: enable Dependabot to update deps and update base image tag

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/src/main/docker/"
+    schedule:
+      interval: "daily"

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11
+FROM eclipse-temurin:11.0.16_8-jdk
 
 ADD kafdrop.sh /
 ADD kafdrop*tar.gz /


### PR DESCRIPTION
Dependabot will now create pull requests when new Docker images, dependencies or GitHub actions become available. By fixing the base image tag, we always exactly know what base image we are using and Dependabot will propose updates.

This will reduce the probability of accumulating known vulnerabilities, like suggested in #403