### PR TITLE
:seedling: Add hostAliases to the deployment.yaml and values.yaml files

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}        
     spec:
+      {{- if .Values.hostAliases }}
+      hostAliases:
+        {{ toYaml .Values.hostAliases | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -66,6 +66,8 @@ affinity: {}
 
 podAnnotations: {}
 
+hostAliases: []
+
 mountProtoDesc: 
   enabled: false
   hostPath:


### PR DESCRIPTION
In this pull request, I have added `hostAliases` in deployment manifest and also put it in values.yaml file.