### PR TITLE
Update Dockerfile to use current JDK version

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.16_8-jdk
+FROM eclipse-temurin:11.0.17_8-jdk
 
 ADD kafdrop.sh /
 ADD kafdrop*tar.gz /


### PR DESCRIPTION
Update JDK to current version as it seems that dependabot doesn't react on the latest JDK 11.