### PR TITLE
Dependabot: ignore major Java version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,6 @@ updates:
     directory: "/src/main/docker/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Now that dependabot/dependabot-core#5758 is closed, it's possible to instruct Dependabot to ignore major version updates for Java