### PR TITLE
Fix link from partition to detail page when a message.format is set.

### DIFF
--- a/src/main/resources/templates/topic-detail.ftlh
+++ b/src/main/resources/templates/topic-detail.ftlh
@@ -124,7 +124,7 @@
                 <tbody>
                 <#list topic.partitions as p>
                     <tr>
-                        <td><a href="<@spring.url '/topic/${topic.name}/messages?partition=${p.id}&offset=${p.firstOffset}&count=100&keyFormat=${keyFormat}&format=${format}'/>">${p.id}</a></td>
+                        <td><a href="<@spring.url '/topic/${topic.name}/messages?partition=${p.id}&offset=${p.firstOffset}&count=100'/>">${p.id}</a></td>
                         <td>${p.firstOffset}</td>
                         <td>${p.size}</td>
                         <td>${p.size - p.firstOffset}</td>


### PR DESCRIPTION
If a message format is set, the link from partition to the detail isn't correct. The detail page response with an exception stack trace.