### PR TITLE
Don't remove KAFKA_PROPERTIES_FILE; allow user to use mounted file

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,10 +268,12 @@ EOF
 
 docker run -d --rm -p 9000:9000 \
     -v $(pwd)/kafka.properties:/tmp/kafka.properties:ro \
+    -v $(pwd)/kafka.truststore.jks:/tmp/kafka.truststore.jks:ro \
+    -v $(pwd)/kafka.keystore.jks:/tmp/kafka.keystore.jks:ro \
     -e KAFKA_BROKERCONNECT=<host:port,host:port> \
     -e KAFKA_PROPERTIES_FILE=/tmp/kafka.properties \
-    -e KAFKA_TRUSTSTORE="$(cat kafka.truststore.jks | base64)" \   # optional
-    -e KAFKA_KEYSTORE="$(cat kafka.keystore.jks | base64)" \       # optional
+    -e KAFKA_TRUSTSTORE_FILE=/tmp/kafka.truststore.jks \   # optional
+    -e KAFKA_KEYSTORE_FILE=/tmp/kafka.keystore.jks \       # optional
     obsidiandynamics/kafdrop
 ```
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,19 @@ docker run -d --rm -p 9000:9000 \
     -e KAFKA_KEYSTORE="$(cat kafka.keystore.jks | base64)" \       # optional
     obsidiandynamics/kafdrop
 ```
+
+Rather than passing `KAFKA_PROPERTIES` as a base64-encoded string, you can also place a pre-populated `KAFKA_PROPERTIES_FILE` into the container:
+
+```sh
+docker run -d --rm -p 9000:9000 \
+    -v $(pwd)/kafka.properties:/tmp/kafka.properties:ro \
+    -e KAFKA_BROKERCONNECT=<host:port,host:port> \
+    -e KAFKA_PROPERTIES_FILE=/tmp/kafka.properties \
+    -e KAFKA_TRUSTSTORE="$(cat kafka.truststore.jks | base64)" \   # optional
+    -e KAFKA_KEYSTORE="$(cat kafka.keystore.jks | base64)" \       # optional
+    obsidiandynamics/kafdrop
+```
+
 #### Environment Variables
 ##### Basic configuration
 |Name                   |Description

--- a/README.md
+++ b/README.md
@@ -260,6 +260,12 @@ docker run -d --rm -p 9000:9000 \
 Rather than passing `KAFKA_PROPERTIES` as a base64-encoded string, you can also place a pre-populated `KAFKA_PROPERTIES_FILE` into the container:
 
 ```sh
+cat << EOF > kafka.properties
+security.protocol=SASL_SSL
+sasl.mechanism=SCRAM-SHA-512
+sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="foo" password="bar"
+EOF
+
 docker run -d --rm -p 9000:9000 \
     -v $(pwd)/kafka.properties:/tmp/kafka.properties:ro \
     -e KAFKA_BROKERCONNECT=<host:port,host:port> \

--- a/src/main/docker/kafdrop.sh
+++ b/src/main/docker/kafdrop.sh
@@ -39,24 +39,24 @@ KAFKA_PROPERTIES_FILE=${KAFKA_PROPERTIES_FILE:-kafka.properties}
 if [ "$KAFKA_PROPERTIES" != "" ]; then
   echo Writing Kafka properties into $KAFKA_PROPERTIES_FILE
   echo "$KAFKA_PROPERTIES" | base64 --decode --ignore-garbage > $KAFKA_PROPERTIES_FILE
-else
-  if [ ! -f $KAFKA_PROPERTIES_FILE ]; then touch $KAFKA_PROPERTIES_FILE; fi
+elif [ ! -f $KAFKA_PROPERTIES_FILE ]; then
+  touch $KAFKA_PROPERTIES_FILE
 fi
 
 KAFKA_TRUSTSTORE_FILE=${KAFKA_TRUSTSTORE_FILE:-kafka.truststore.jks}
 if [ "$KAFKA_TRUSTSTORE" != "" ]; then
   echo Writing Kafka truststore into $KAFKA_TRUSTSTORE_FILE
   echo "$KAFKA_TRUSTSTORE" | base64 --decode --ignore-garbage > $KAFKA_TRUSTSTORE_FILE
-else
-  rm $KAFKA_TRUSTSTORE_FILE |& > /dev/null | true
+elif [ ! -f $KAFKA_TRUSTSTORE_FILE ]; then
+  touch $KAFKA_TRUSTSTORE_FILE
 fi
 
 KAFKA_KEYSTORE_FILE=${KAFKA_KEYSTORE_FILE:-kafka.keystore.jks}
 if [ "$KAFKA_KEYSTORE" != "" ]; then
   echo Writing Kafka keystore into $KAFKA_KEYSTORE_FILE
   echo "$KAFKA_KEYSTORE" | base64 --decode --ignore-garbage > $KAFKA_KEYSTORE_FILE
-else
-  rm $KAFKA_KEYSTORE_FILE |& > /dev/null | true
+elif [ ! -f $KAFKA_KEYSTORE_FILE ]; then
+  touch $KAFKA_KEYSTORE_FILE
 fi
 
 ARGS="--add-opens=java.base/sun.nio.ch=ALL-UNNAMED -Xss256K \

--- a/src/main/docker/kafdrop.sh
+++ b/src/main/docker/kafdrop.sh
@@ -40,7 +40,7 @@ if [ "$KAFKA_PROPERTIES" != "" ]; then
   echo Writing Kafka properties into $KAFKA_PROPERTIES_FILE
   echo "$KAFKA_PROPERTIES" | base64 --decode --ignore-garbage > $KAFKA_PROPERTIES_FILE
 else
-  rm $KAFKA_PROPERTIES_FILE |& > /dev/null | true
+  touch $KAFKA_PROPERTIES_FILE
 fi
 
 KAFKA_TRUSTSTORE_FILE=${KAFKA_TRUSTSTORE_FILE:-kafka.truststore.jks}

--- a/src/main/docker/kafdrop.sh
+++ b/src/main/docker/kafdrop.sh
@@ -39,6 +39,8 @@ KAFKA_PROPERTIES_FILE=${KAFKA_PROPERTIES_FILE:-kafka.properties}
 if [ "$KAFKA_PROPERTIES" != "" ]; then
   echo Writing Kafka properties into $KAFKA_PROPERTIES_FILE
   echo "$KAFKA_PROPERTIES" | base64 --decode --ignore-garbage > $KAFKA_PROPERTIES_FILE
+else
+  if [ ! -f $KAFKA_PROPERTIES_FILE ]; then touch $KAFKA_PROPERTIES_FILE; fi
 fi
 
 KAFKA_TRUSTSTORE_FILE=${KAFKA_TRUSTSTORE_FILE:-kafka.truststore.jks}

--- a/src/main/docker/kafdrop.sh
+++ b/src/main/docker/kafdrop.sh
@@ -40,7 +40,7 @@ if [ "$KAFKA_PROPERTIES" != "" ]; then
   echo Writing Kafka properties into $KAFKA_PROPERTIES_FILE
   echo "$KAFKA_PROPERTIES" | base64 --decode --ignore-garbage > $KAFKA_PROPERTIES_FILE
 else
-  touch $KAFKA_PROPERTIES_FILE
+  if [ -f $KAFKA_PROPERTIES_FILE ]; then touch $KAFKA_PROPERTIES_FILE; else rm -f $KAFKA_PROPERTIES_FILE; fi
 fi
 
 KAFKA_TRUSTSTORE_FILE=${KAFKA_TRUSTSTORE_FILE:-kafka.truststore.jks}

--- a/src/main/docker/kafdrop.sh
+++ b/src/main/docker/kafdrop.sh
@@ -39,8 +39,6 @@ KAFKA_PROPERTIES_FILE=${KAFKA_PROPERTIES_FILE:-kafka.properties}
 if [ "$KAFKA_PROPERTIES" != "" ]; then
   echo Writing Kafka properties into $KAFKA_PROPERTIES_FILE
   echo "$KAFKA_PROPERTIES" | base64 --decode --ignore-garbage > $KAFKA_PROPERTIES_FILE
-else
-  if [ -f $KAFKA_PROPERTIES_FILE ]; then touch $KAFKA_PROPERTIES_FILE; else rm -f $KAFKA_PROPERTIES_FILE; fi
 fi
 
 KAFKA_TRUSTSTORE_FILE=${KAFKA_TRUSTSTORE_FILE:-kafka.truststore.jks}


### PR DESCRIPTION
This change gives users the option to put their _own_ `KAFKA_PROPERTIES_FILE` into an image _without_ specifying `KAFKA_PROPERTIES`.

This is particularly useful in cases where a user does not want to store `KAFKA_PROPERTIES` in version control such as Git. (Even though it is base64-encoded, it is not encrypted.)