### PR TITLE
fix: message.keyFormat not working

### DIFF
--- a/src/main/java/kafdrop/controller/MessageController.java
+++ b/src/main/java/kafdrop/controller/MessageController.java
@@ -149,7 +149,7 @@ public final class MessageController {
       defaultForm.setOffset(0l);
       defaultForm.setPartition(0);
       defaultForm.setFormat(defaultFormat);
-      defaultForm.setKeyFormat(defaultFormat);
+      defaultForm.setKeyFormat(defaultKeyFormat);
       defaultForm.setIsAnyProto(protobufProperties.getParseAnyProto());
 
       model.addAttribute("messageForm", defaultForm);


### PR DESCRIPTION
On the messages page the default value for key format should be defaultKeyFormat, not defaultFormat