### PR TITLE
Ignoring unnecessarily generated docker-ready

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,4 +29,4 @@ jobs:
         distribution: 'adopt'
         cache: maven
     - name: Build with Maven
-      run: mvn -B verify --file pom.xml
+      run: mvn -B verify --file pom.xml -Dskip.docker.resources=true

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <protobuf.version>3.22.3</protobuf.version>
         <testcontainers.version>1.18.0</testcontainers.version>
         <kafka-libs.version>7.3.3</kafka-libs.version>
+        <skip.docker.resources>false</skip.docker.resources>
     </properties>
 
     <scm>
@@ -280,6 +281,7 @@
                                     <filtering>true</filtering>
                                 </resource>
                             </resources>
+                            <skip>${skip.docker.resources}</skip>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
In our analysis, we observe that target/docker-ready is generated but not used in CI. Because the contents of docker-ready/ are not accessed after they are generation, we propose to disable the generation of this directory to save build runtime. The generation of this directory can be disabled by simply adding a property element to the pom.xml or adding an argument to the mvn command. The argument to add to the mvn command is -Dskip.docker.resources=true.