### PR TITLE
Check out full-depth

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
     - name: Checkout src repo
       uses: actions/checkout@v3
+      with:
+        # Full git history is needed to get a proper list of changed files within `super-linter`
+        fetch-depth: 0
+
     - name: Lint code base
       uses: github/super-linter@v4
       env:


### PR DESCRIPTION
Full git history is needed to get a proper list of changed files within `super-linter`

This should resolve the below error that currently occurs on pretty much all pull request builds:

```
2023-04-18 21:34:51 [ERROR]   Failed to switch back to branch!
2023-04-18 21:34:51 [FATAL]   [fatal: reference is not a tree: 3afa21b5f9bef8e81396e3572a598d089e710b96]
```