### PR TITLE
Ignoring unnecessarily generated surefire-report

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,4 +33,4 @@ jobs:
         distribution: 'adopt'
         cache: maven
     - name: Build with Maven
-      run: mvn -B verify --file pom.xml
+      run: mvn -B verify --file pom.xml -Dsurefire.useFile=false -DdisableXmlReport=true


### PR DESCRIPTION
In our analysis, we observe that this target/surefire-report/ directory is generated but not later used during the CI build. Hence, we propose to disable generating this directory to save runtime.
The generation of this directory can be disabled by simply adding -Dsurefire.useFile=false -DdisableXmlReport=true to the mvn command.