### PR TITLE
Revert "Bump spring-boot-starter-parent from 3.0.7 to 3.1.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.0.7</version>
     </parent>
     <groupId>com.obsidiandynamics.kafdrop</groupId>
     <artifactId>kafdrop</artifactId>


### PR DESCRIPTION
Reverts obsidiandynamics/kafdrop#528

I didn't notice the failed pull request check.