### PR TITLE
Remove obsolete compiler config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,10 +214,6 @@
                     <source>17</source>
                     <target>17</target>
                     <fork>true</fork>
-                    <compilerVersion>17</compilerVersion>
-                    <compilerArgs>
-                        <arg>--add-exports=jdk.management.agent/jdk.internal.agent=ALL-UNNAMED</arg>
-                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Because it conflicts with Spring Boot Starter parent 3.1.0. That now uses --release, which is incompatible with --add-exports.