### PR TITLE
Leave configuration files untouched

### DIFF
--- a/src/main/docker/kafdrop.sh
+++ b/src/main/docker/kafdrop.sh
@@ -40,24 +40,18 @@ KAFKA_PROPERTIES_FILE=${KAFKA_PROPERTIES_FILE:-kafka.properties}
 if [ "$KAFKA_PROPERTIES" != "" ]; then
   echo Writing Kafka properties into $KAFKA_PROPERTIES_FILE
   echo "$KAFKA_PROPERTIES" | base64 --decode --ignore-garbage > $KAFKA_PROPERTIES_FILE
-elif [ ! -f $KAFKA_PROPERTIES_FILE ]; then
-  touch $KAFKA_PROPERTIES_FILE
 fi
 
 KAFKA_TRUSTSTORE_FILE=${KAFKA_TRUSTSTORE_FILE:-kafka.truststore.jks}
 if [ "$KAFKA_TRUSTSTORE" != "" ]; then
   echo Writing Kafka truststore into $KAFKA_TRUSTSTORE_FILE
   echo "$KAFKA_TRUSTSTORE" | base64 --decode --ignore-garbage > $KAFKA_TRUSTSTORE_FILE
-elif [ ! -f $KAFKA_TRUSTSTORE_FILE ]; then
-  touch $KAFKA_TRUSTSTORE_FILE
 fi
 
 KAFKA_KEYSTORE_FILE=${KAFKA_KEYSTORE_FILE:-kafka.keystore.jks}
 if [ "$KAFKA_KEYSTORE" != "" ]; then
   echo Writing Kafka keystore into $KAFKA_KEYSTORE_FILE
   echo "$KAFKA_KEYSTORE" | base64 --decode --ignore-garbage > $KAFKA_KEYSTORE_FILE
-elif [ ! -f $KAFKA_KEYSTORE_FILE ]; then
-  touch $KAFKA_KEYSTORE_FILE
 fi
 
 ARGS="--add-opens=java.base/sun.nio.ch=ALL-UNNAMED -Xss256K \


### PR DESCRIPTION
Earlier, we used to delete the following files if existing:
* kafka.properties
* kafka.truststore.jks
* kafka.keystore.jks

Since #502, we are creating them if not existing. With this commit, we take the middle ground: let the user decide about the existence.

Fixes #579