### PR TITLE
Add chart-release actions workflow

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -1,0 +1,28 @@
+# reference: https://helm.sh/docs/howto/chart_releaser_action/#github-actions-workflow
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/chart/index.yaml
+++ b/chart/index.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+entries: {}
+generated: "2024-04-03T17:43:58.307779939+02:00"


### PR DESCRIPTION
This PR adds a release workflow as described [on the official helm website](https://helm.sh/docs/howto/chart_releaser_action/#github-actions-workflow).
I can't really test this though, so I am not sure if this works

Related: #236, #357