### PR TITLE
try to fix "Add chart-release actions workflow #630" by using charts_…

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -26,3 +26,5 @@ jobs:
         uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          charts_dir: chart


### PR DESCRIPTION
…dir: chart

This PR tries to use the `charts_dir` directive, because in this repo the name is `chart` instead of the default `charts`.


Related: https://github.com/obsidiandynamics/kafdrop/issues/236, https://github.com/obsidiandynamics/kafdrop/issues/357, https://github.com/obsidiandynamics/kafdrop/issues/360