### PR TITLE
GroupId Link 404 Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ kafka.properties*
 kafka.truststore.jks*
 kafka.keystore.jks*
 /.vs
+.java-version

--- a/src/main/java/kafdrop/controller/ConsumerController.java
+++ b/src/main/java/kafdrop/controller/ConsumerController.java
@@ -32,6 +32,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 @Tag(name = "consumer-controller", description = "Consumer Controller")
 @Controller
 @RequestMapping("/consumer")
@@ -44,7 +47,7 @@ public final class ConsumerController {
 
   @RequestMapping("/{groupId:.+}")
   public String consumerDetail(@PathVariable("groupId") String groupId, Model model) throws ConsumerNotFoundException {
-    final var consumer = kafkaMonitor.getConsumersByGroup(groupId).stream().findAny();
+    final var consumer = kafkaMonitor.getConsumersByGroup(new String(Base64.getDecoder().decode(groupId), StandardCharsets.UTF_8)).stream().findAny();
 
     model.addAttribute("consumer", consumer.orElseThrow(() -> new ConsumerNotFoundException(groupId)));
     return "consumer-detail";
@@ -58,7 +61,7 @@ public final class ConsumerController {
   @GetMapping(path = "/{groupId:.+}", produces = MediaType.APPLICATION_JSON_VALUE)
   public @ResponseBody ConsumerVO getConsumer(@PathVariable("groupId") String groupId)
     throws ConsumerNotFoundException {
-    final var consumer = kafkaMonitor.getConsumersByGroup(groupId).stream().findAny();
+    final var consumer = kafkaMonitor.getConsumersByGroup(new String(Base64.getDecoder().decode(groupId), StandardCharsets.UTF_8)).stream().findAny();
 
     return consumer.orElseThrow(() -> new ConsumerNotFoundException(groupId));
   }

--- a/src/main/java/kafdrop/model/ConsumerVO.java
+++ b/src/main/java/kafdrop/model/ConsumerVO.java
@@ -20,6 +20,8 @@ package kafdrop.model;
 
 import org.apache.commons.lang3.Validate;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
@@ -27,15 +29,22 @@ import java.util.TreeMap;
 
 public final class ConsumerVO implements Comparable<ConsumerVO> {
   private final String groupId;
+
+  private final String groupIdBase64;
   private final Map<String, ConsumerTopicVO> topics = new TreeMap<>();
 
   public ConsumerVO(String groupId) {
     Validate.notEmpty("groupId is required");
     this.groupId = groupId;
+    this.groupIdBase64 = new String (Base64.getEncoder().encode(groupId.getBytes(StandardCharsets.UTF_8)));
   }
 
   public String getGroupId() {
     return groupId;
+  }
+
+  public String getGroupIdBase64() {
+    return groupIdBase64;
   }
 
   public void addTopic(ConsumerTopicVO topic) {

--- a/src/main/resources/templates/topic-detail.ftlh
+++ b/src/main/resources/templates/topic-detail.ftlh
@@ -156,7 +156,7 @@
                 <tbody>
                 <#list consumers![] as c>
                     <tr>
-                        <td><a href="<@spring.url '/consumer/${c.groupId}'/>">${c.groupId}</a></td>
+                        <td><a href="<@spring.url '/consumer/${c.groupIdBase64}'/>">${c.groupId}</a></td>
                         <td>${c.getTopic(topic.name).lag}</td>
                     </tr>
                 </#list>


### PR DESCRIPTION
- Introduce base64 groupId.
- Use encoded groupId in link.
-  Fix 404 error incase groupd id contains HTML tags.

Relates to #641