### PR TITLE
chore: add favicon

### DIFF
--- a/src/main/resources/templates/lib/template.ftlh
+++ b/src/main/resources/templates/lib/template.ftlh
@@ -22,7 +22,7 @@
     <link type="text/css" rel="stylesheet" href="<@spring.url '/css/bootstrap.min.css'/>"/>
     <link type="text/css" rel="stylesheet" href="<@spring.url '/css/font-awesome.min.css'/>"/>
     <link type="text/css" rel="stylesheet" href="<@spring.url '/css/global.css'/>"/>
-    <link rel="icon" type="image/svg+xml" href="<@spring.url '/images/kafdrop-logo.svg'/>">
+    <link type="image/svg+xml" rel="icon" href="<@spring.url '/images/kafdrop-logo.svg'/>">
 
     <script src="<@spring.url '/js/jquery-3.5.1.slim.min.js'/>"></script>
     <script src="<@spring.url '/js/bootstrap.bundle.min.js'/>"></script>

--- a/src/main/resources/templates/lib/template.ftlh
+++ b/src/main/resources/templates/lib/template.ftlh
@@ -22,6 +22,7 @@
     <link type="text/css" rel="stylesheet" href="<@spring.url '/css/bootstrap.min.css'/>"/>
     <link type="text/css" rel="stylesheet" href="<@spring.url '/css/font-awesome.min.css'/>"/>
     <link type="text/css" rel="stylesheet" href="<@spring.url '/css/global.css'/>"/>
+    <link rel="icon" type="image/svg+xml" href="<@spring.url '/images/kafdrop-logo.svg'/>">
 
     <script src="<@spring.url '/js/jquery-3.5.1.slim.min.js'/>"></script>
     <script src="<@spring.url '/js/bootstrap.bundle.min.js'/>"></script>


### PR DESCRIPTION
SVG already exists, just a matter of including it in the `<header>`. Fixes #359.

Tested via:

```
mvn clean package
java --add-opens=java.base/sun.nio.ch=ALL-UNNAMED  \
  -jar target/kafdrop-4.0.2-SNAPSHOT.jar \
  --kafka.brokerConnect=$KAFKA
```

Results: 
<img width="161" alt="image" src="https://github.com/obsidiandynamics/kafdrop/assets/61571670/b77e04e7-a674-4292-950c-2ca5207eab2a">
