### PR TITLE
Multi-arch/arm64 support

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -25,6 +25,14 @@ jobs:
         echo "app_ver=$(mvn -B help:evaluate -Dexpression=project.version -q -DforceStdout)"
         echo "app_ver=$(mvn -B help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
 
+    -
+      name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    -
+      name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
 # Docker hub action
     -
       name: Login to Docker Hub

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,9 +24,18 @@ jobs:
       run: |
         echo "app_ver=$(mvn -B help:evaluate -Dexpression=project.version -q -DforceStdout)"
         echo "app_ver=$(mvn -B help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
+
+# Docker hub action
+    -
+      name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
     -
       name: Build with Maven
-      run: mvn -B clean integration-test package assembly:single docker:build
+      run: mvn -B clean integration-test package assembly:single docker:build docker:push
 
 # github_release:
     -
@@ -40,19 +49,7 @@ jobs:
         commit: "master"
         generateReleaseNotes: true
 
-# Docker hub action
-    -
-      name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }} 
-    -
-      name: push snapshot version
-      run: |
-        echo publishing docker container $app_ver
-        docker push docker.io/obsidiandynamics/kafdrop:$app_ver
     -
       name: push latest if it's a release
       if: ${{ ! endsWith( env.app_ver, '-SNAPSHOT' ) }}
-      run: docker push docker.io/obsidiandynamics/kafdrop:latest
+      run: docker buildx imagetools create docker.io/obsidiandynamics/kafdrop:$app_ver --tag docker.io/obsidiandynamics/kafdrop:latest

--- a/pom.xml
+++ b/pom.xml
@@ -239,24 +239,24 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
+                <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>1.2.2</version>
+                <version>0.45.0</version>
                 <configuration>
-                    <imageName>obsidiandynamics/kafdrop</imageName>
-                    <forceTags>true</forceTags>
-                    <dockerDirectory>${project.build.directory}/docker-ready</dockerDirectory>
-                    <imageTags>
-                        <imageTag>${project.version}</imageTag>
-                        <imageTag>latest</imageTag>
-                    </imageTags>
-                    <resources>
-                        <resource>
-                            <targetPath>/</targetPath>
-                            <directory>${project.build.directory}</directory>
-                            <include>${project.build.finalName}-bin.tar.gz</include>
-                        </resource>
-                    </resources>
+                    <images>
+                        <image>
+                            <name>obsidiandynamics/kafdrop:${project.version}</name>
+                            <build>
+                                <assemblies>
+                                    <assembly>
+                                        <descriptorRef>artifact</descriptorRef>
+                                    </assembly>
+                                </assemblies>
+                                <contextDir>${project.build.directory}/docker-ready</contextDir>
+                                <noCache>true</noCache>
+                            </build>
+                        </image>
+                    </images>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <protobuf.version>3.25.5</protobuf.version>
         <testcontainers.version>1.20.3</testcontainers.version>
         <kafka-libs.version>7.7.1</kafka-libs.version>
+        <docker.platforms>linux/amd64,linux/arm64</docker.platforms>
     </properties>
 
     <scm>
@@ -252,6 +253,11 @@
                                         <descriptorRef>artifact</descriptorRef>
                                     </assembly>
                                 </assemblies>
+                                <buildx>
+                                    <platforms>
+                                        <platform>${docker.platforms}</platform>
+                                    </platforms>
+                                </buildx>
                                 <contextDir>${project.build.directory}/docker-ready</contextDir>
                                 <noCache>true</noCache>
                             </build>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:17.0.13_11-jdk
 
 ADD kafdrop.sh /
-ADD kafdrop*tar.gz /
+ADD maven/ /kafdrop/
 
 RUN chmod +x /kafdrop.sh
 


### PR DESCRIPTION
This PR consists of several small changes:
* **Replaced com.spotify:docker-maven-plugin with io.fabric8:docker-maven-plugin**
Old library is deprecated and does not have buildx support
* **Modified GHA to build and push in the same job stage**
Needed for buildx built images
* **Added buildx and QEMU actions to GHA**
Needed for multi-arch Docker images

I did a brief test on my personal repo by changing GHA code a bit to publish to personal registry and to see if :latest tagging still works as expected. Also ran this on my x86_64 laptop and additionally a t4g.small (aarch64) VM.
Code for the test: https://github.com/Blefish/kafdrop/tree/multi-arch-test
And the test images: https://github.com/Blefish/kafdrop/pkgs/container/kafdrop

Closes #627
