### PR TITLE
Fix Protobuf Message NoClassDefFoundError

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <!-- name of parameter changed in latest mvn javadoc plugin version-->
         <additionalOptions>-Xdoclint:none</additionalOptions>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <protobuf.version>4.27.3</protobuf.version>
+        <protobuf.version>3.25.4</protobuf.version>
         <testcontainers.version>1.20.1</testcontainers.version>
         <kafka-libs.version>7.7.0</kafka-libs.version>
     </properties>


### PR DESCRIPTION
Fixes #284 

[io.confluent.kafka-protobuf-serializer not support protobuf 4.x version](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/serdes-protobuf.html#limitations-and-developer-notes)
