### PR TITLE
Add support for truststore and keystore password parameters in Kafdrop

### DIFF
--- a/src/main/java/kafdrop/config/KafkaConfiguration.java
+++ b/src/main/java/kafdrop/config/KafkaConfiguration.java
@@ -29,8 +29,10 @@ public final class KafkaConfiguration {
   private String saslMechanism;
   private String securityProtocol;
   private String truststoreFile;
+  private String truststorePassword;
   private String propertiesFile;
   private String keystoreFile;
+  private String keystorePassword;
 
   public void applyCommon(Properties properties) {
     properties.setProperty(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, brokerConnect);
@@ -43,12 +45,18 @@ public final class KafkaConfiguration {
     if (new File(truststoreFile).isFile()) {
       LOG.info("Assigning truststore location to {}", truststoreFile);
       properties.put("ssl.truststore.location", truststoreFile);
+      if (truststorePassword != null && !truststorePassword.isEmpty()) {
+        properties.put("ssl.truststore.password", truststorePassword);
+      }
     }
 
     LOG.info("Checking keystore file {}", keystoreFile);
     if (new File(keystoreFile).isFile()) {
       LOG.info("Assigning keystore location to {}", keystoreFile);
       properties.put("ssl.keystore.location", keystoreFile);
+      if (keystorePassword != null && !keystorePassword.isEmpty()) {
+        properties.put("ssl.keystore.password", keystorePassword);
+      }
     }
 
     LOG.info("Checking properties file {}", propertiesFile);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,5 +41,7 @@ kafka:
   saslMechanism: "PLAIN"
   securityProtocol: "SASL_PLAINTEXT"
   truststoreFile: "${KAFKA_TRUSTSTORE_FILE:kafka.truststore.jks}"
-  propertiesFile : "${KAFKA_PROPERTIES_FILE:kafka.properties}"
   keystoreFile: "${KAFKA_KEYSTORE_FILE:kafka.keystore.jks}"
+  propertiesFile: "${KAFKA_PROPERTIES_FILE:kafka.properties}"
+  truststorePassword: "${KAFKA_TRUSTSTORE_PASSWORD}"
+  keystorePassword: "${KAFKA_KEYSTORE_PASSWORD}"


### PR DESCRIPTION
## Description

This PR introduces support for specifying passwords for the truststore and keystore used in SSL communication with Kafka brokers in Kafdrop. 

Previously, while the truststore file location could be specified using the `KAFKA_TRUSTSTORE_FILE` parameter, there was no way to provide the password required to access it. 

This enhancement addresses that limitation.

refer: https://docs.oracle.com/javadb/10.8.3.0/adminguide/cadminsslclient.html

## Key changes include

1. New Configuration Parameters

- Added `KAFKA_TRUSTSTORE_PASSWORD` to specify the truststore password.
- Added `KAFKA_KEYSTORE_PASSWORD` to specify the keystore password.

2. Code Changes

- Modified `KafkaConfiguration.java` to handle these new parameters and set `ssl.truststore.password` and `ssl.keystore.password` in the Kafka properties if provided.
- Ensured that these parameters are optional, maintaining backward compatibility for users who do not require truststore or keystore passwords.

3. Configuration File Updates

- Updated application.yml to include placeholders for the new parameters, making them configurable via environment variables:
    - `KAFKA_TRUSTSTORE_PASSWORD`
    - `KAFKA_KEYSTORE_PASSWORD`
