### PR TITLE
Add Support for SASL/SCRAM Authentication in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,8 +252,6 @@ Kafdrop supports TLS (SSL) and SASL connections for [encryption and authenticati
 * `kafka.properties`: specifying the necessary configuration, including key/truststore passwords, cipher suites, enabled TLS protocol versions, username/password pairs, etc. When supplying the truststore and/or keystore files, the `ssl.truststore.location` and `ssl.keystore.location` properties will be assigned automatically.
 
 ### Running from JAR
-Connect kafka with SASL/SCRAM Authentication
-
 First create a `kafka.properties` file with the following content:
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -251,6 +251,23 @@ Kafdrop supports TLS (SSL) and SASL connections for [encryption and authenticati
 * `kafka.keystore.jks`: specifying the private key to authenticate the client to the broker, if mutual TLS authentication is required.
 * `kafka.properties`: specifying the necessary configuration, including key/truststore passwords, cipher suites, enabled TLS protocol versions, username/password pairs, etc. When supplying the truststore and/or keystore files, the `ssl.truststore.location` and `ssl.keystore.location` properties will be assigned automatically.
 
+### Running from JAVA
+Connect kafka with SASL/SCRAM Authentication
+
+first create a kafka.properties file with the following content:
+
+```yml
+sasl.mechanism: SCRAM-SHA-256
+security.protocol: SASL_PLAINTEXT
+sasl.jaas.config: org.apache.kafka.common.security.scram.ScramLoginModule required username="your_username" password="your_password";
+```
+
+then run kafdrop with the following command:
+
+```shell
+/opt/java/bin/java -jar ./kafdrop-4.1.0.jar --kafka.brokerConnect=xx.xx.xx.xx:9092 --kafka.propertiesFile=./kafka.properties
+```
+
 ### Using Docker
 The three files above can be supplied to a Docker instance in base-64-encoded form via environment variables:
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Kafdrop supports TLS (SSL) and SASL connections for [encryption and authenticati
 ### Running from JAVA
 Connect kafka with SASL/SCRAM Authentication
 
-first create a kafka.properties file with the following content:
+First create a `kafka.properties` file with the following content:
 
 ```yml
 sasl.mechanism: SCRAM-SHA-256

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Kafdrop supports TLS (SSL) and SASL connections for [encryption and authenticati
 * `kafka.keystore.jks`: specifying the private key to authenticate the client to the broker, if mutual TLS authentication is required.
 * `kafka.properties`: specifying the necessary configuration, including key/truststore passwords, cipher suites, enabled TLS protocol versions, username/password pairs, etc. When supplying the truststore and/or keystore files, the `ssl.truststore.location` and `ssl.keystore.location` properties will be assigned automatically.
 
-### Running from JAVA
+### Running from JAR
 Connect kafka with SASL/SCRAM Authentication
 
 First create a `kafka.properties` file with the following content:

--- a/README.md
+++ b/README.md
@@ -255,9 +255,9 @@ Kafdrop supports TLS (SSL) and SASL connections for [encryption and authenticati
 First create a `kafka.properties` file with the following content:
 
 ```yml
-sasl.mechanism: SCRAM-SHA-256
-security.protocol: SASL_PLAINTEXT
-sasl.jaas.config: org.apache.kafka.common.security.scram.ScramLoginModule required username="your_username" password="your_password";
+security.protocol=SASL_SSL
+sasl.mechanism=SCRAM-SHA-512
+sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="foo" password="bar"
 ```
 
 Then run Kafdrop with the following command:

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ security.protocol: SASL_PLAINTEXT
 sasl.jaas.config: org.apache.kafka.common.security.scram.ScramLoginModule required username="your_username" password="your_password";
 ```
 
-then run kafdrop with the following command:
+Then run Kafdrop with the following command:
 
 ```shell
 /opt/java/bin/java -jar ./kafdrop-4.1.0.jar --kafka.brokerConnect=xx.xx.xx.xx:9092 --kafka.propertiesFile=./kafka.properties

--- a/README.md
+++ b/README.md
@@ -265,7 +265,9 @@ sasl.jaas.config: org.apache.kafka.common.security.scram.ScramLoginModule requir
 Then run Kafdrop with the following command:
 
 ```shell
-/opt/java/bin/java -jar ./kafdrop-4.1.0.jar --kafka.brokerConnect=xx.xx.xx.xx:9092 --kafka.propertiesFile=./kafka.properties
+java -jar target/kafdrop-<version>.jar \
+    --kafka.brokerConnect=<host:port,host:port> \
+    --kafka.propertiesFile=./kafka.properties
 ```
 
 ### Using Docker


### PR DESCRIPTION
## Add Support for SASL/SCRAM Authentication in README

### Description

This pull request adds detailed instructions to the README for configuring and running Kafdrop with a Kafka cluster that has SASL/SCRAM authentication enabled. The changes include:

- Instructions for creating a `kafka.properties` file with the necessary SASL/SCRAM configuration.
- A command to run Kafdrop with the JAR file and the `kafka.properties` file.

### Changes

- Added a section in the README titled "Running from JAR with SASL/SCRAM Authentication".
- Provided a sample `kafka.properties` file with the required configuration.
- Included a command to start Kafdrop with the JAR file and the `kafka.properties` file.

### Testing

- Tested the configuration and command locally to ensure Kafdrop connects successfully to a Kafka cluster with SASL/SCRAM authentication.

### Example
```shell
Create kafka.properties file
echo "sasl.mechanism=SCRAM-SHA-256 security.protocol=SASL_PLAINTEXT sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="your_username" password="your_password";" > kafka.properties
Run Kafdrop with the JAR file
java --add-opens=java.base/sun.nio.ch=ALL-UNNAMED -Dkafka.properties.file=kafka.properties -jar target/kafdrop-<version>.jar --kafka.brokerConnect=host:port,host:port
```


### Conclusion

These changes will help users who are working with Kafka clusters that have SASL/SCRAM authentication enabled to configure and run Kafdrop more easily.

Please review and let me know if any further changes are needed.

Thank you