### PR TITLE
Add logging level configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,39 @@ docker run -d --rm -p 9000:9000 \
 | `SSL_KEY_STORE_PASSWORD` | Keystore password
 | `SSL_KEY_ALIAS`          | Key alias
 
+
+##### Logging level configuration
+
+Kafdrop supports configuring logging levels through environment variables.
+For example, setting:
+
+```sh
+LOGGING_LEVEL_ROOT=WARN
+```
+will set the root logger level to WARN.
+
+Logger endpoints are exposed via Spring Boot Actuator at: `/actuator/loggers`
+
+In addition to the root logger, you can fine-tune log verbosity for specific Kafdrop packages such as `kafdrop`, `kafdrop.config`, `kafdrop.service`, and `kafdrop.controller`.
+
+| Environment Variable               | Description |
+|------------------------------------|-------------|
+| `LOGGING_LEVEL_ROOT`               | Logging level for the root logger (`ERROR`, `WARN`, `INFO`, `DEBUG`, or `TRACE`) |
+| `LOGGING_LEVEL_KAFDROP`            | Logging level for the `kafdrop` logger (`ERROR`, `WARN`, `INFO`, `DEBUG`, or `TRACE`) |
+| `LOGGING_LEVEL_KAFDROP_CONFIG`     | Logging level for the `kafdrop.config` logger (`ERROR`, `WARN`, `INFO`, `DEBUG`, or `TRACE`) |
+| `LOGGING_LEVEL_KAFDROP_SERVICE`    | Logging level for the `kafdrop.service` logger (`ERROR`, `WARN`, `INFO`, `DEBUG`, or `TRACE`) |
+| `LOGGING_LEVEL_KAFDROP_CONTROLLER` | Logging level for the `kafdrop.controller` logger (`ERROR`, `WARN`, `INFO`, `DEBUG`, or `TRACE`) |
+
+A typical production configuration might set:
+
+```sh
+LOGGING_LEVEL_ROOT=WARN
+LOGGING_LEVEL_KAFDROP_CONFIG=WARN
+```
+to reduce log verbosity while keeping other Kafdrop logs at INFO.
+
+For more information on configuring logging in Spring Boot applications, see the official [Spring Boot logging documentation](https://docs.spring.io/spring-boot/reference/features/logging.html).
+
 ### Using Helm
 Like in the Docker example, supply the files in base-64 form:
 

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -65,6 +65,16 @@ spec:
 {{- else }}
             value: "{{ .Values.cmdArgs }}"
 {{- end }}
+          - name: LOGGING_LEVEL_ROOT
+            value: {{ .Values.logging.root.level | upper | quote }}
+          - name: LOGGING_LEVEL_KAFDROP
+            value: {{ .Values.logging.kafdrop.level | upper | quote }}
+          - name: LOGGING_LEVEL_KAFDROP_CONFIG
+            value: {{ .Values.logging.kafdrop.config.level | upper | quote }}
+          - name: LOGGING_LEVEL_KAFDROP_SERVICE
+            value: {{ .Values.logging.kafdrop.service.level | upper | quote }}
+          - name: LOGGING_LEVEL_KAFDROP_CONTROLLER
+            value: {{ .Values.logging.kafdrop.controller.level | upper | quote }}
 
           ports:
             - name: http

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -58,6 +58,23 @@ resources:
     cpu: 1m
     memory: 128Mi
 
+logging:
+  root:
+    # Logging level for the root logger (TRACE, DEBUG, INFO, WARN, ERROR)
+    level: WARN
+  kafdrop:
+    # Logging level for the kafdrop logger (TRACE, DEBUG, INFO, WARN, ERROR)
+    level: INFO
+    config:
+      # Logging level for kafdrop.config logger (TRACE, DEBUG, INFO, WARN, ERROR)
+      level: WARN
+    service:
+      # Logging level for the kafdrop.service logger (TRACE, DEBUG, INFO, WARN, ERROR)
+      level: INFO
+    controller:
+      # Logging level for the kafdrop.controller logger (TRACE, DEBUG, INFO, WARN, ERROR)
+      level: INFO
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
Address issues #422 and #644.
Add section in the README on how to configure Kafdrop logging level using environment variables.
Add logging level configuration to the Helm chart. 