### PR TITLE
Add support for using PEM certificate files for UI SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,8 @@ docker run -d --rm -p 9000:9000 \
 | `KAFKA_TRUSTSTORE_FILE`  |Internal location where the truststore file will be written to (if `KAFKA_TRUSTSTORE` is set). Defaults to `kafka.truststore.jks`.
 | `KAFKA_KEYSTORE_FILE`    |Internal location where the keystore file will be written to (if `KAFKA_KEYSTORE` is set). Defaults to `kafka.keystore.jks`.
 | `SSL_ENABLED`            | Enabling HTTPS (SSL) for Kafdrop server. Default is `false`
+| `SSL_CERTIFICATE`        | Path to PEM-encoded certificate chain file (alternative to keystore)
+| `SSL_CERTIFICATE_PRIVATE_KEY` | Path to PEM-encoded private key file (alternative to keystore)
 | `SSL_KEY_STORE_TYPE`     | Type of SSL keystore. Default is `PKCS12`
 | `SSL_KEY_STORE`          | Path to keystore file
 | `SSL_KEY_STORE_PASSWORD` | Keystore password

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,11 +7,13 @@ server:
     whitelabel:
       enabled: false
   ssl:
+    enabled: ${SSL_ENABLED:false}
+    certificate: ${SSL_CERTIFICATE:}
+    certificate-private-key: ${SSL_CERTIFICATE_PRIVATE_KEY:}
     key-store-type: ${SSL_KEY_STORE_TYPE:PKCS12}
     key-store: ${SSL_KEY_STORE:}
     key-store-password: ${SSL_KEY_STORE_PASSWORD:}
     key-alias: ${SSL_KEY_ALIAS:}
-    enabled: ${SSL_ENABLED:false}
 
 spring:
   jmx:


### PR DESCRIPTION
I wanted to be able to deploy a normal certificate just for the webui, without having to convert it to a jave keystore. Luckily this is already built into Spring Boot.

Users now have two ways to enable SSL:

PEM files:
SSL_ENABLED=true
SSL_CERTIFICATE=/path/to/cert-chain.pem
SSL_CERTIFICATE_PRIVATE_KEY=/path/to/key.pem

Keystore (existing):
SSL_ENABLED=true
SSL_KEY_STORE=/path/to/keystore.p12
SSL_KEY_STORE_PASSWORD=secret
SSL_KEY_ALIAS=kafdrop

Spring Boot uses whichever set is provided. Users should provide one or the other, not both.

I tested a build quickly with a locally generated cert and it seemed to work.