### PR TITLE
Show highest last offset and its partition on topic detail

### DIFF
--- a/src/main/resources/templates/topic-detail.ftlh
+++ b/src/main/resources/templates/topic-detail.ftlh
@@ -86,7 +86,7 @@
                     <#assign maxOffsetPartition = topic.partitions?sequence?sort_by("size")?last>
                 </#if>
                 <tr>
-                    <td>Highest last offset</td>
+                    <td>Highest end offset</td>
                     <td><#if ((maxOffsetPartition.size)!0) gt 0>${maxOffsetPartition.size} (partition ${maxOffsetPartition.id})<#else>-</#if></td>
                 </tr>
                 </tbody>

--- a/src/main/resources/templates/topic-detail.ftlh
+++ b/src/main/resources/templates/topic-detail.ftlh
@@ -82,6 +82,13 @@
                     <td>Total available messages</td>
                     <td>${topic.availableSize}</td>
                 </tr>
+                <#if topic.partitions?size gt 0>
+                    <#assign maxOffsetPartition = topic.partitions?sequence?sort_by("size")?last>
+                </#if>
+                <tr>
+                    <td>Highest last offset</td>
+                    <td><#if ((maxOffsetPartition.size)!0) gt 0>${maxOffsetPartition.size} (partition ${maxOffsetPartition.id})<#else>-</#if></td>
+                </tr>
                 </tbody>
             </table>
         </div>


### PR DESCRIPTION
Partition table already lists the offsets, this saves eyeballing the column to find the head of the topic. 
Empty topic renders as `-`.

<img width="750" height="338" alt="kafdrop-overview-empty" src="https://github.com/user-attachments/assets/27e8443a-1c06-459f-8cfa-62a2f46df7c9" />
<img width="750" height="338" alt="kafdrop-overview-table" src="https://github.com/user-attachments/assets/7441b38c-e986-40b1-b60a-3d6f2d91c91e" />