### PR TITLE
fix: make one offset request

### DIFF
--- a/src/main/java/kafdrop/service/KafkaHighLevelAdminClient.java
+++ b/src/main/java/kafdrop/service/KafkaHighLevelAdminClient.java
@@ -6,6 +6,7 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConsumerGroupListing;
 import org.apache.kafka.clients.admin.DeleteTopicsOptions;
+import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsSpec;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -33,6 +34,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -105,6 +107,31 @@ public final class KafkaHighLevelAdminClient {
         throw new KafkaAdminClientException(e);
       }
     }
+  }
+
+  Map<String, Map<TopicPartition, OffsetAndMetadata>> listConsumerGroupOffsetsBatch(Set<String> groupIds) {
+    if (groupIds.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    final var groupSpecs = groupIds.stream()
+      .collect(Collectors.toMap(Function.identity(), _ -> new ListConsumerGroupOffsetsSpec()));
+    final var result = adminClient.listConsumerGroupOffsets(groupSpecs);
+
+    final var offsetsByGroup = new HashMap<String, Map<TopicPartition, OffsetAndMetadata>>(groupIds.size(), 1f);
+    for (var groupId : groupIds) {
+      try {
+        offsetsByGroup.put(groupId, result.partitionsToOffsetAndMetadata(groupId).get());
+      } catch (InterruptedException | ExecutionException e) {
+        if (e.getCause() instanceof GroupAuthorizationException) {
+          LOG.info("Not authorized to view consumer group {}; skipping", groupId);
+          offsetsByGroup.put(groupId, Collections.emptyMap());
+        } else {
+          throw new KafkaAdminClientException(e);
+        }
+      }
+    }
+    return offsetsByGroup;
   }
 
   Map<String, Config> describeTopicConfigs(Set<String> topicNames) {

--- a/src/main/java/kafdrop/service/KafkaHighLevelAdminClient.java
+++ b/src/main/java/kafdrop/service/KafkaHighLevelAdminClient.java
@@ -6,6 +6,7 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConsumerGroupListing;
 import org.apache.kafka.clients.admin.DeleteTopicsOptions;
+import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsResult;
 import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsSpec;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -97,16 +98,8 @@ public final class KafkaHighLevelAdminClient {
 
   Map<TopicPartition, OffsetAndMetadata> listConsumerGroupOffsetsIfAuthorized(String groupId) {
     final var offsets = adminClient.listConsumerGroupOffsets(groupId);
-    try {
-      return offsets.partitionsToOffsetAndMetadata().get();
-    } catch (InterruptedException | ExecutionException e) {
-      if (e.getCause() instanceof GroupAuthorizationException) {
-        LOG.info("Not authorized to view consumer group {}; skipping", groupId);
-        return Collections.emptyMap();
-      } else {
-        throw new KafkaAdminClientException(e);
-      }
-    }
+
+    return getGroupOffsets(offsets, groupId);
   }
 
   Map<String, Map<TopicPartition, OffsetAndMetadata>> listConsumerGroupOffsetsBatch(Set<String> groupIds) {
@@ -120,18 +113,26 @@ public final class KafkaHighLevelAdminClient {
 
     final var offsetsByGroup = new HashMap<String, Map<TopicPartition, OffsetAndMetadata>>(groupIds.size(), 1f);
     for (var groupId : groupIds) {
-      try {
-        offsetsByGroup.put(groupId, result.partitionsToOffsetAndMetadata(groupId).get());
-      } catch (InterruptedException | ExecutionException e) {
-        if (e.getCause() instanceof GroupAuthorizationException) {
-          LOG.info("Not authorized to view consumer group {}; skipping", groupId);
-          offsetsByGroup.put(groupId, Collections.emptyMap());
-        } else {
-          throw new KafkaAdminClientException(e);
-        }
+      offsetsByGroup.put(groupId, getGroupOffsets(result, groupId));
+    }
+
+    return offsetsByGroup;
+  }
+
+  private Map<TopicPartition, OffsetAndMetadata> getGroupOffsets(ListConsumerGroupOffsetsResult result, String groupId) {
+    try {
+      return result.partitionsToOffsetAndMetadata(groupId).get();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new KafkaAdminClientException(e);
+    } catch (ExecutionException e) {
+      if (e.getCause() instanceof GroupAuthorizationException) {
+        LOG.info("Not authorized to view consumer group {}; skipping", groupId);
+        return Collections.emptyMap();
+      } else {
+        throw new KafkaAdminClientException(e);
       }
     }
-    return offsetsByGroup;
   }
 
   Map<String, Config> describeTopicConfigs(Set<String> topicNames) {

--- a/src/main/java/kafdrop/service/KafkaHighLevelAdminClient.java
+++ b/src/main/java/kafdrop/service/KafkaHighLevelAdminClient.java
@@ -119,7 +119,8 @@ public final class KafkaHighLevelAdminClient {
     return offsetsByGroup;
   }
 
-  private Map<TopicPartition, OffsetAndMetadata> getGroupOffsets(ListConsumerGroupOffsetsResult result, String groupId) {
+  private Map<TopicPartition, OffsetAndMetadata> getGroupOffsets(ListConsumerGroupOffsetsResult result,
+                                                                 String groupId) {
     try {
       return result.partitionsToOffsetAndMetadata(groupId).get();
     } catch (InterruptedException e) {

--- a/src/main/java/kafdrop/service/KafkaMonitorImpl.java
+++ b/src/main/java/kafdrop/service/KafkaMonitorImpl.java
@@ -420,11 +420,12 @@ public final class KafkaMonitorImpl implements KafkaMonitor {
 
   private List<ConsumerGroupOffsets> getConsumerOffsets(Set<String> topics) {
     final var consumerGroups = highLevelAdminClient.listConsumerGroups();
-    return consumerGroups.stream()
-      .map(this::resolveOffsets)
+    final var offsetsByGroup = highLevelAdminClient.listConsumerGroupOffsetsBatch(consumerGroups);
+    return offsetsByGroup.entrySet().stream()
+      .map(entry -> new ConsumerGroupOffsets(entry.getKey(), entry.getValue()))
       .map(offsets -> offsets.forTopics(topics))
       .filter(not(ConsumerGroupOffsets::isEmpty))
-      .collect(Collectors.toList());
+      .toList();
   }
 
   @Override


### PR DESCRIPTION
On large clusters, the page for viewing a single topic loads excruciatingly slow. 

Currently, Kafdrop make a separate request to get the offsets for each consumer group in the cluster when the page loads. This PR changes it to make one request for all the groups as recommended by the admin client docs.

> The operation method's first parameter is a Collection of items to perform the operation on. Batching multiple requests into a single call is more efficient and should be preferred over multiple calls to the same method.